### PR TITLE
In spitftbitmap example sketch, close SD file after use

### DIFF
--- a/examples/spitftbitmap/spitftbitmap.pde
+++ b/examples/spitftbitmap/spitftbitmap.pde
@@ -95,6 +95,7 @@ void setup(void) {
   
   if (! bmpReadHeader(bmpFile)) { 
      Serial.println("bad bmp");
+     bmpFile.close();
      return;
   }
   
@@ -105,6 +106,7 @@ void setup(void) {
   
 
   bmpdraw(bmpFile, 0, 0);
+  bmpFile.close();
 }
 
 void loop() {


### PR DESCRIPTION
In spitftbitmap example sketch, close SD file after use
so that people who follow the example and use copy and paste will wind
up with code that works more than once.
