### PR TITLE
Changed Bcmd, ... from deprecated type (prog_uchar) to type (const uint8_t PROGMEM)

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -94,7 +94,7 @@ void Adafruit_ST7735::writedata(uint8_t c) {
 // formatting -- storage-wise this is hundreds of bytes more compact
 // than the equivalent code.  Companion function follows.
 #define DELAY 0x80
-PROGMEM static prog_uchar
+static const uint8_t PROGMEM
   Bcmd[] = {                  // Initialization commands for 7735B screens
     18,                       // 18 commands in list:
     ST7735_SWRESET,   DELAY,  //  1: Software reset, no args, w/delay
@@ -228,7 +228,7 @@ PROGMEM static prog_uchar
 
 // Companion code to the above tables.  Reads and issues
 // a series of LCD commands stored in PROGMEM byte array.
-void Adafruit_ST7735::commandList(uint8_t *addr) {
+void Adafruit_ST7735::commandList(const uint8_t *addr) {
 
   uint8_t  numCommands, numArgs;
   uint16_t ms;
@@ -253,7 +253,7 @@ void Adafruit_ST7735::commandList(uint8_t *addr) {
 
 
 // Initialization code common to both 'B' and 'R' type displays
-void Adafruit_ST7735::commonInit(uint8_t *cmdList) {
+void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
 
   constructor(ST7735_TFTWIDTH, ST7735_TFTHEIGHT);
   colstart  = rowstart = 0; // May be overridden in init func

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -127,8 +127,8 @@ class Adafruit_ST7735 : public Adafruit_GFX {
   void     spiwrite(uint8_t),
            writecommand(uint8_t c),
            writedata(uint8_t d),
-           commandList(uint8_t *addr),
-           commonInit(uint8_t *cmdList);
+           commandList(const uint8_t *addr),
+           commonInit(const uint8_t *cmdList);
 //uint8_t  spiread(void);
 
   boolean  hwSPI;


### PR DESCRIPTION
Compiling Adafruit-ST7735-Library using avr-libc version 1.8.0 fails, because the prog_uchar has been deprecated[1], and isn't enabled by default.

This patch changes the type of Bcmd, Rcmd1, Rcmd2green, Rcmd2red, and Rcmd3 to const uint8_t with the PROGMEM attribute.

$ avr-g++ -c -Os -Wall -mmcu=atmega32u2 -DARDUINO=101 -I/usr/share/arduino/hardware/arduino/cores/arduino -I/usr/share/arduino/hardware/arduino/variants/mega -I/usr/share/arduino/libraries/SPI -I../Adafruit_GFX -Iutility -I. Adafruit_ST7735.cpp 
Adafruit_ST7735.cpp:97:16: error: ‘prog_uchar’ does not name a type

$ avr-g++ --version
avr-g++ (GCC) 4.7.0
Copyright (C) 2012 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

[1] http://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html#gaa475b6b81fd8b34de45695da1da523b6
