### PR TITLE
Support Teensy 3.0 & 3.1 using AVR code

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -51,6 +51,10 @@ Adafruit_ST7735::Adafruit_ST7735(uint8_t cs, uint8_t rs, uint8_t rst) :
   _sid  = _sclk = 0;
 }
 
+#if defined(CORE_TEENSY) && !defined(__AVR__)
+#define __AVR__
+#endif
+
 #ifdef __AVR__
 inline void Adafruit_ST7735::spiwrite(uint8_t c) {
 

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -146,7 +146,7 @@ class Adafruit_ST7735 : public Adafruit_GFX {
 
   boolean  hwSPI;
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(CORE_TEENSY)
 volatile uint8_t *dataport, *clkport, *csport, *rsport;
   uint8_t  _cs, _rs, _rst, _sid, _sclk,
            datapinmask, clkpinmask, cspinmask, rspinmask,


### PR DESCRIPTION
This library's AVR code works great on Teensy 3.0 & 3.1, because Teensy emulates the necessary AVR registers.  Unfortunately, the recent changes for Arduino Due cause the AVR code to no longer be used with compiling for Teensy3.

Please consider merging this tiny patch.  It merely enables the AVR code to be used again for Teensy3.
