### PR TITLE
Correct the init. sequence documentation

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -183,14 +183,14 @@ static const uint8_t PROGMEM
       10,                     //     10 ms delay
     ST7735_PWCTR6 , 2      ,  // 12: Power control, 2 args, no delay:
       0x11, 0x15,
-    ST7735_GMCTRP1,16      ,  // 13: Magical unicorn dust, 16 args, no delay:
-      0x09, 0x16, 0x09, 0x20, //     (seriously though, not sure what
-      0x21, 0x1B, 0x13, 0x19, //      these config values represent)
+    ST7735_GMCTRP1,16      ,  // 13: Gamma Adjustments (pos. polarity), 16 args + delay:
+      0x09, 0x16, 0x09, 0x20, //      (Not entirely necessary, but provides
+      0x21, 0x1B, 0x13, 0x19, //       accurate colors)
       0x17, 0x15, 0x1E, 0x2B,
       0x04, 0x05, 0x02, 0x0E,
-    ST7735_GMCTRN1,16+DELAY,  // 14: Sparkles and rainbows, 16 args + delay:
-      0x0B, 0x14, 0x08, 0x1E, //     (ditto)
-      0x22, 0x1D, 0x18, 0x1E,
+    ST7735_GMCTRN1,16+DELAY,  // 14: Gamma Adjustments (neg. polarity), 16 args + delay:
+      0x0B, 0x14, 0x08, 0x1E, //      (Not entirely necessary, but provides
+      0x22, 0x1D, 0x18, 0x1E, //       accurate colors)
       0x1B, 0x1A, 0x24, 0x2B,
       0x06, 0x06, 0x02, 0x0F,
       10,                     //     10 ms delay
@@ -261,14 +261,14 @@ static const uint8_t PROGMEM
 
   Rcmd3[] = {                 // Init for 7735R, part 3 (red or green tab)
     4,                        //  4 commands in list:
-    ST7735_GMCTRP1, 16      , //  1: Magical unicorn dust, 16 args, no delay:
-      0x02, 0x1c, 0x07, 0x12,
-      0x37, 0x32, 0x29, 0x2d,
+    ST7735_GMCTRP1, 16      , //  1: Gamma Adjustments (pos. polarity), 16 args + delay:
+      0x02, 0x1c, 0x07, 0x12, //     (Not entirely necessary, but provides
+      0x37, 0x32, 0x29, 0x2d, //      accurate colors)
       0x29, 0x25, 0x2B, 0x39,
       0x00, 0x01, 0x03, 0x10,
-    ST7735_GMCTRN1, 16      , //  2: Sparkles and rainbows, 16 args, no delay:
-      0x03, 0x1d, 0x07, 0x06,
-      0x2E, 0x2C, 0x29, 0x2D,
+    ST7735_GMCTRN1, 16      , //  2: Gamma Adjustments (neg. polarity), 16 args + delay:
+      0x03, 0x1d, 0x07, 0x06, //     (Not entirely necessary, but provides
+      0x2E, 0x2C, 0x29, 0x2D, //      accurate colors)
       0x2E, 0x2E, 0x37, 0x3F,
       0x00, 0x00, 0x02, 0x10,
     ST7735_NORON  ,    DELAY, //  3: Normal display on, no args, w/delay


### PR DESCRIPTION
The init. sequence was **_poorly_** documented. I mean, come on, "magical unicorn dust"?

``` c
ST7735_GMCTRP1,16,       // 13: Magical unicorn dust, 16 args, no delay:
0x09, 0x16, 0x09, 0x20,  //     (seriously though, not sure what
0x21, 0x1B, 0x13, 0x19,  //     these config values represent)
```

Doing some basic research I found the datasheet and updated the documentation accordingly:

``` c
ST7735_GMCTRP1,16,      // 13: Gamma Adjustments (pos. polarity), 16 args + delay:
0x09, 0x16, 0x09, 0x20, //     (Not entirely necessary, but provides
0x21, 0x1B, 0x13, 0x19, //     accurate colors)
```

Info on **pages 148-151** on this ST7735 datasheet: ftp://imall.iteadstudio.com/IM120419001_ITDB02_1.8SP/DS_ST7735.pdf
