### PR TITLE
Adding pushColors to push multiple pixels in one call.

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -445,6 +445,33 @@ void Adafruit_ST7735::pushColor(uint16_t color) {
 #endif
 }
 
+void Adafruit_ST7735::pushColors(uint16_t *colors, uint8_t offset, uint8_t len) {
+#ifdef __AVR__
+  *rsport |=  rspinmask;
+  *csport &= ~cspinmask;
+#endif
+#if defined(__SAM3X8E__)
+  rsport->PIO_SODR |=  rspinmask;
+  csport->PIO_CODR  |=  cspinmask;
+#endif
+  
+  colors = colors + offset*2;
+  for (uint8_t i = 0; i < len; ++i) {
+    uint16_t color = *colors;
+    spiwrite(color >> 8);
+    spiwrite(color);
+    colors++;
+  }
+
+#ifdef __AVR__
+  *csport |= cspinmask;
+#endif
+#if defined(__SAM3X8E__)
+  csport->PIO_SODR  |=  cspinmask;
+#endif
+}
+
+
 void Adafruit_ST7735::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
   if((x < 0) ||(x >= _width) || (y < 0) || (y >= _height)) return;

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -116,6 +116,7 @@ class Adafruit_ST7735 : public Adafruit_GFX {
            initR(uint8_t options = INITR_GREENTAB), // for ST7735R
            setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1),
            pushColor(uint16_t color),
+           pushColors(uint16_t *colors, uint8_t offset, uint8_t len),
            fillScreen(uint16_t color),
            drawPixel(int16_t x, int16_t y, uint16_t color),
            drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),


### PR DESCRIPTION
I've been working on faster ways of blitting images onto the screen.  Storing them on an SD card in the correct RGB565 format allows reading bytes from the file and sending them directly to the TFT without needing to do any reformatting.  Doing bulk operations has been key to making that faster.  So far, using a 256 byte buffer (128 pixels), I've sped up drawing a full-screen image from 1 second, to 355ms.
Being able to push multiple pixels/colors at once is the only change needed in the TFT library.
