### PR TITLE
Use SPI transactions.

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -81,6 +81,9 @@ inline void Adafruit_ST7735::spiwrite(uint8_t c) {
 
 
 void Adafruit_ST7735::writecommand(uint8_t c) {
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
   *rsport &= ~rspinmask;
   *csport &= ~cspinmask;
 
@@ -88,10 +91,16 @@ void Adafruit_ST7735::writecommand(uint8_t c) {
   spiwrite(c);
 
   *csport |= cspinmask;
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
+#endif
 }
 
 
 void Adafruit_ST7735::writedata(uint8_t c) {
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
     
@@ -99,7 +108,10 @@ void Adafruit_ST7735::writedata(uint8_t c) {
   spiwrite(c);
 
   *csport |= cspinmask;
-} 
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
+#endif
+}
 #endif //#ifdef __AVR__
 
 #if defined(__SAM3X8E__)
@@ -122,6 +134,9 @@ inline void Adafruit_ST7735::spiwrite(uint8_t c) {
 
 
 void Adafruit_ST7735::writecommand(uint8_t c) {
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
   rsport->PIO_CODR |=  rspinmask;
   csport->PIO_CODR  |=  cspinmask;
   
@@ -129,10 +144,16 @@ void Adafruit_ST7735::writecommand(uint8_t c) {
   spiwrite(c);
   
   csport->PIO_SODR  |=  cspinmask;
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
+#endif
 }
 
 
 void Adafruit_ST7735::writedata(uint8_t c) {
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
   rsport->PIO_SODR |=  rspinmask;
   csport->PIO_CODR  |=  cspinmask;
   
@@ -140,7 +161,10 @@ void Adafruit_ST7735::writedata(uint8_t c) {
   spiwrite(c);
   
   csport->PIO_SODR  |=  cspinmask;
-} 
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
+#endif
+}
 #endif //#if defined(__SAM3X8E__)
 
 
@@ -336,6 +360,9 @@ void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
 
   if(hwSPI) { // Using hardware SPI
     SPI.begin();
+#ifdef SPI_HAS_TRANSACTION
+    spisettings = SPISettings(4000000L, MSBFIRST, SPI_MODE0);
+#else
 #ifdef __AVR__
     SPI.setClockDivider(SPI_CLOCK_DIV4); // 4 MHz (half speed)
     //Due defaults to 4mHz (clock divider setting of 21)
@@ -346,6 +373,7 @@ void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
 #endif
     SPI.setBitOrder(MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
+#endif // SPI_HAS_TRANSACTION
   } else {
     pinMode(_sclk, OUTPUT);
     pinMode(_sid , OUTPUT);
@@ -444,6 +472,10 @@ void Adafruit_ST7735::setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1,
 
 
 void Adafruit_ST7735::pushColor(uint16_t color) {
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
+
 #ifdef __AVR__
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
@@ -461,6 +493,10 @@ void Adafruit_ST7735::pushColor(uint16_t color) {
 #endif
 #if defined(__SAM3X8E__)
   csport->PIO_SODR  |=  cspinmask;
+#endif
+  
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
 #endif
 }
 
@@ -470,6 +506,10 @@ void Adafruit_ST7735::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
   setAddrWindow(x,y,x+1,y+1);
 
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
+
 #ifdef __AVR__
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
@@ -487,6 +527,10 @@ void Adafruit_ST7735::drawPixel(int16_t x, int16_t y, uint16_t color) {
 #endif
 #if defined(__SAM3X8E__)
   csport->PIO_SODR  |=  cspinmask;
+#endif
+
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
 #endif
 }
 
@@ -500,6 +544,10 @@ void Adafruit_ST7735::drawFastVLine(int16_t x, int16_t y, int16_t h,
   setAddrWindow(x, y, x, y+h-1);
 
   uint8_t hi = color >> 8, lo = color;
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
+
 #ifdef __AVR__
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
@@ -518,6 +566,10 @@ void Adafruit_ST7735::drawFastVLine(int16_t x, int16_t y, int16_t h,
 #if defined(__SAM3X8E__)
   csport->PIO_SODR  |=  cspinmask;
 #endif
+
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
+#endif
 }
 
 
@@ -530,6 +582,10 @@ void Adafruit_ST7735::drawFastHLine(int16_t x, int16_t y, int16_t w,
   setAddrWindow(x, y, x+w-1, y);
 
   uint8_t hi = color >> 8, lo = color;
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
+
 #ifdef __AVR__
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
@@ -547,6 +603,10 @@ void Adafruit_ST7735::drawFastHLine(int16_t x, int16_t y, int16_t w,
 #endif
 #if defined(__SAM3X8E__)
   csport->PIO_SODR  |=  cspinmask;
+#endif
+
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
 #endif
 }
 
@@ -570,6 +630,10 @@ void Adafruit_ST7735::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   setAddrWindow(x, y, x+w-1, y+h-1);
 
   uint8_t hi = color >> 8, lo = color;
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.beginTransaction(spisettings);
+#endif
+
 #ifdef __AVR__
   *rsport |=  rspinmask;
   *csport &= ~cspinmask;
@@ -590,6 +654,10 @@ void Adafruit_ST7735::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 #endif
 #if defined(__SAM3X8E__)
   csport->PIO_SODR  |=  cspinmask;
+#endif
+
+#ifdef SPI_HAS_TRANSACTION
+  if (hwSPI) SPI.endTransaction();
 #endif
 }
 

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -31,6 +31,7 @@ as well as Adafruit raw 1.8" TFT display
  #include "WProgram.h"
 #endif
 
+#include <SPI.h>
 #include <Adafruit_GFX.h>
 
 #if defined(__SAM3X8E__)
@@ -162,6 +163,9 @@ class Adafruit_ST7735 : public Adafruit_GFX {
 //uint8_t  spiread(void);
 
   boolean  hwSPI;
+#ifdef SPI_HAS_TRANSACTION
+  SPISettings spisettings;
+#endif
 
 #if defined(__AVR__) || defined(CORE_TEENSY)
 volatile uint8_t *dataport, *clkport, *csport, *rsport;


### PR DESCRIPTION
Use SPI.beginTransaction() and SPI.endTransaction() to prevent other
libraries from using SPI in interrupts in the middle of our SPI
transactions (i.e. while our CS is asserted). This seems to help
prevent conflicts when using the CC3000 with this display.

Only applies to hardware SPI and only if the Arduino SPI library
supports it (SPI_HAS_TRANSACTION is defined). Applies to both AVR and
SAM (Arduino Due).

Requires an #include <SPI.h> in Adafruit_ST7735.h for SPISettings.
