### PR TITLE
Port to the Particle Core

### DIFF
--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -27,6 +27,8 @@ as well as Adafruit raw 1.8" TFT display
 #if ARDUINO >= 100
  #include "Arduino.h"
  #include "Print.h"
+#elif PARTICLE
+ #include "Particle.h"
 #else
  #include "WProgram.h"
 #endif
@@ -48,6 +50,10 @@ as well as Adafruit raw 1.8" TFT display
 #if defined(__SAM3X8E__)
     #undef __FlashStringHelper::F(string_literal)
     #define F(string_literal) string_literal
+#endif
+
+#if defined(PARTICLE)
+typedef uint32_t RwReg;
 #endif
 
 // some flags for initR() :(

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit ST7735 Library
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit 1.8" SPI displays.

--- a/spark.json
+++ b/spark.json
@@ -1,0 +1,7 @@
+{
+    "name": "Adafruit ST7735",
+    "author": "Adafruit <info@adafruit.com>",
+    "license": "MIT",
+    "version": "1.0.4",
+    "description": "This is a library for the Adafruit ST7735 based SPI displays."
+}


### PR DESCRIPTION
- The Particle lacks bitmasks/ports, but has pinSetFast/pinResetFast methods to replace them for performance.
- Particle supports Arduino style SPI.setClockDivider, but also has a setClockSpeed, which allows getting close to the 15 MHz limit supported by the chip, despite different reference clocks between systems.
- spark.json will allow this repo to be included from the WebIDE.

(should work with Photon as well)