### PR TITLE
Add method to set rowstart and colstart

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -393,7 +393,16 @@ void Adafruit_ST7735::initR(uint8_t options) {
   tabcolor = options;
 }
 
-
+#if defined(__AVR__) || defined(CORE_TEENSY)
+void Adafruit_ST7735::setRowColStart(uint8_t startRow, uint8_t startCol ) {
+#elif defined(__arm__)
+void Adafruit_ST7735::setRowColStart(uint32_t startRow, uint32_t startCol ) {
+#elif defined(ESP8266)
+void Adafruit_ST7735::setRowColStart(uint32_t startRow, uint32_t startCol ) {
+#endif
+	rowstart=startRow;
+	colstart=startCol;
+}
 void Adafruit_ST7735::setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1,
  uint8_t y1) {
 

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -151,7 +151,14 @@ class Adafruit_ST7735 : public Adafruit_GFX {
   uint32_t readcommand32(uint8_t);
   void     dummyclock(void);
   */
-
+ protected:
+#if defined(__AVR__) || defined(CORE_TEENSY)
+  void setRowColStart(uint8_t startRow, uint8_t startCol );
+#elif defined(__arm__)
+  void setRowColStart(uint32_t startRow, uint32_t startCol );
+#elif defined(ESP8266)
+  void setRowColStart(uint32_t startRow, uint32_t startCol );
+#endif
  private:
   uint8_t  tabcolor;
 


### PR DESCRIPTION
Useful in cases where one might need to change these in a subclass.

I bought some 128x128 LCDS from eBay with the ST7735 driver chip and needed to set the rowstart and colstart fields.  This change adds a setRowColStart method that sets those two fields and it is protected so that only subclasses can call it.
