### PR TITLE
Fix rotation 2 and 3 for 1.44" TFT display

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -315,7 +315,10 @@ void Adafruit_ST7735::commandList(const uint8_t *addr) {
 
 // Initialization code common to both 'B' and 'R' type displays
 void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
-  ystart = xstart = colstart  = rowstart = 0; // May be overridden in init func
+  // May be overridden in init func
+  colstart = rowstart = 0;
+  colstart2 = rowstart2 = 0;
+  xstart = ystart = 0;
 
   pinMode(_dc, OUTPUT);
   pinMode(_cs, OUTPUT);
@@ -387,20 +390,20 @@ void Adafruit_ST7735::initR(uint8_t options) {
   commonInit(Rcmd1);
   if(options == INITR_GREENTAB) {
     commandList(Rcmd2green);
-    colstart = 2;
-    rowstart = 1;
+    colstart = colstart2 = 2;
+    rowstart = rowstart2 = 1;
   } else if(options == INITR_144GREENTAB) {
     _height = ST7735_TFTHEIGHT_128;
     _width = ST7735_TFTWIDTH_128;
     commandList(Rcmd2green144);
-    colstart = 2;
-    rowstart = 3;
+    colstart = colstart2 = 2;
+    rowstart = 3; rowstart2 = 1;
   } else if(options == INITR_MINI160x80) {
     _height = ST7735_TFTHEIGHT_160;
     _width = ST7735_TFTWIDTH_80;
     commandList(Rcmd2green160x80);
-    colstart = 24;
-    rowstart = 0;
+    colstart = colstart2 = 24;
+    rowstart = rowstart2 = 0;
   } else {
     // colstart, rowstart left at default '0' values
     commandList(Rcmd2red);
@@ -628,7 +631,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
        _width = ST7735_TFTHEIGHT_160;
        _height = ST7735_TFTWIDTH_128;
      }
-     ystart = colstart;
+     ystart = colstart2;
      xstart = rowstart;
      break;
   case 2:
@@ -648,8 +651,8 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
        _height = ST7735_TFTHEIGHT_160;
        _width  = ST7735_TFTWIDTH_128;
      }
-     xstart = colstart;
-     ystart = rowstart;
+     xstart = colstart2;
+     ystart = rowstart2;
      break;
    case 3:
      if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
@@ -669,7 +672,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
        _height = ST7735_TFTWIDTH_128;
      }
      ystart = colstart;
-     xstart = rowstart;
+     xstart = rowstart2;
      break;
   }
 }

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -176,7 +176,11 @@ class Adafruit_ST7735 : public Adafruit_GFX {
   boolean  hwSPI;
 
   int8_t  _cs, _dc, _rst, _sid, _sclk;
-  uint8_t colstart, rowstart, xstart, ystart; // some displays need this changed
+
+  // some displays need these changed
+  uint8_t colstart, rowstart;
+  uint8_t colstart2, rowstart2;
+  uint8_t xstart, ystart;
 
 #if defined(USE_FAST_IO)
   volatile RwReg  *dataport, *clkport, *csport, *dcport;


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

This adds another set of colstart/rowstart variables to be used with the different rotation modes and changes their values for the 1.44" TFT display in order to fix the display bounds in rotation modes 2 and 3. This allows the rotation test to display correctly and the "scrolling Mario clouds" project to work in rotation mode 3 without glitches.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

The change only affects the 1.44" TFT display. Other displays are unaffected.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Tested with graphicstest, rotationtest, and "scrolling Mario clouds".