### PR TITLE
Fix for broken rotation mode 2/3 on ST7789 1.54" TFT

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -44,6 +44,8 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height) {
 
   _colstart = ST7789_240x240_XSTART;
   _rowstart = ST7789_240x240_YSTART;
+  _colstart2 = ST7789_240x240_XSTART;
+  _rowstart2 = 0;
   _height = 240;
   _width = 240;
 
@@ -73,16 +75,16 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
      break;
   case 2:
      writedata(ST77XX_MADCTL_RGB);
- 
-     _xstart = _colstart;
-     _ystart = _rowstart;
+
+     _xstart = _colstart2;
+     _ystart = _rowstart2;
      break;
 
    case 3:
      writedata(ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB);
 
-     _xstart = _rowstart;
-     _ystart = _colstart;
+     _xstart = _rowstart2;
+     _ystart = _colstart2;
      break;
   }
 }

--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -44,7 +44,6 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height) {
 
   _colstart = ST7789_240x240_XSTART;
   _rowstart = ST7789_240x240_YSTART;
-  _colstart2 = ST7789_240x240_XSTART;
   _rowstart2 = 0;
   _height = 240;
   _width = 240;
@@ -76,7 +75,7 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
   case 2:
      writedata(ST77XX_MADCTL_RGB);
 
-     _xstart = _colstart2;
+     _xstart = _colstart;
      _ystart = _rowstart2;
      break;
 
@@ -84,7 +83,7 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
      writedata(ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB);
 
      _xstart = _rowstart2;
-     _ystart = _colstart2;
+     _ystart = _colstart;
      break;
   }
 }

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -138,7 +138,7 @@ class Adafruit_ST77xx : public Adafruit_GFX {
 
 
  protected:
-  uint8_t  _colstart, _rowstart, _xstart, _ystart; // some displays need this changed
+  uint8_t  _colstart, _colstart2, _rowstart, _rowstart2, _xstart, _ystart; // some displays need this changed
 
   void     displayInit(const uint8_t *addr);
   void     spiwrite(uint8_t),

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -138,7 +138,7 @@ class Adafruit_ST77xx : public Adafruit_GFX {
 
 
  protected:
-  uint8_t  _colstart, _colstart2, _rowstart, _rowstart2, _xstart, _ystart; // some displays need this changed
+  uint8_t  _colstart, _rowstart, _rowstart2, _xstart, _ystart; // some displays need this changed
 
   void     displayInit(const uint8_t *addr);
   void     spiwrite(uint8_t),


### PR DESCRIPTION
Resolution for https://github.com/adafruit/Adafruit-ST7735-Library/issues/45

- Arduino board: Tested on Teensy 3.2

- Arduino IDE version (found in Arduino -> About Arduino menu): 1.8.5


The default rotationtest.ino example does not handle rotation modes 2 and 3 correctly on the 1.54" TFT ST7789 board. These two modes are offset by 80 and are not centered.

Adding a second _rowstart2 property provides a fix for this particular board. (I believe this is the same issue noted here: #39 though I don't have that board on hand to test this fix.)