### PR TITLE
Add the ability to pass in a SPIClass (Sercom) to use as the HW SPI

### DIFF
--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -74,7 +74,19 @@ class Adafruit_ST7735 : public Adafruit_ST77xx {
 /**************************************************************************/
  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst) : 
   Adafruit_ST77xx(cs, dc, rst) {}
-  
+
+/**************************************************************************/
+/*!
+    @brief  Instantiate Adafruit ST7735 driver with user selected hardware SPI
+    @param    cs    Chip select pin #
+    @param    dc    Data/Command pin #
+    @param    spiClass  A pointer to the SPIClass to use for HW SPI
+    @param    rst   Reset pin # (optional, pass -1 if unused)
+*/
+/**************************************************************************/
+ Adafruit_ST7735(int8_t cs, int8_t dc, SPIClass *spiClass, int8_t rst) :
+  Adafruit_ST77xx(cs, dc, spiClass, rst) {}
+
   // the tab types are so weird we need to do this 'by hand'
   void  setRotation(uint8_t m);
 

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -27,6 +27,18 @@ class Adafruit_ST7789 : public Adafruit_ST77xx {
 /**************************************************************************/
  Adafruit_ST7789(int8_t cs, int8_t dc, int8_t rst) : 
   Adafruit_ST77xx(cs, dc, rst) {}
+
+/**************************************************************************/
+/*!
+    @brief  Instantiate Adafruit ST7789 driver with user selected hardware SPI
+    @param    cs    Chip select pin #
+    @param    dc    Data/Command pin #
+    @param    spiClass   A pointer to the SPIClass to use for HW SPI
+    @param    rst   Reset pin # (optional, pass -1 if unused)
+*/
+/**************************************************************************/
+ Adafruit_ST7789(int8_t cs, int8_t dc, SPIClass *spiClass, int8_t rst) :
+  Adafruit_ST77xx(cs, dc, spiClass, rst) {}
   
   // the tab types are so weird we need to do this 'by hand'
   void  setRotation(uint8_t m);

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -61,6 +61,19 @@ Adafruit_ST77xx::Adafruit_ST77xx(int8_t cs, int8_t dc, int8_t rst)
 {
 }
 
+/**************************************************************************/
+/*!
+    @brief  Instantiate Adafruit ST77XX driver with user selected hardware SPI
+    @param    cs    Chip select pin #
+    @param    dc    Data/Command pin #
+    @param    spiClass   A pointer to the SPIClass to use for HW SPI
+    @param    rst   Reset pin # (optional, pass -1 if unused)
+*/
+/**************************************************************************/
+Adafruit_ST77xx::Adafruit_ST77xx(int8_t cs, int8_t dc, SPIClass *spiClass, int8_t rst)
+  : Adafruit_SPITFT(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, spiClass, rst)
+{
+}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -94,6 +94,7 @@ class Adafruit_ST77xx : public Adafruit_SPITFT {
 
   Adafruit_ST77xx(int8_t _CS, int8_t _DC, int8_t _MOSI, int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
   Adafruit_ST77xx(int8_t CS, int8_t RS, int8_t RST = -1);
+  Adafruit_ST77xx(int8_t CS, int8_t RS, SPIClass *spiClass, int8_t RST = -1);
 
   // Transaction API not used by GFX
   void      setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);


### PR DESCRIPTION
This change allows a SPIClass pointer to be passed in and used as the HW SPI. 

This change requires pull request https://github.com/adafruit/Adafruit-GFX-Library/pull/178 to be merged first, as this calls into newly added constructors in the Adafruit_SPITFT class.
This allowed me to use the Uncanny Eyes with the Circuit Playground.