### PR TITLE
Add header include guards (fixes #56).

### DIFF
--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -1,3 +1,6 @@
+#ifndef _ADAFRUIT_ST7735H_
+#define _ADAFRUIT_ST7735H_
+
 #include "Adafruit_ST77xx.h"
 
 
@@ -84,3 +87,5 @@ class Adafruit_ST7735 : public Adafruit_ST77xx {
  private:
   uint8_t  tabcolor;
 };
+
+#endif // _ADAFRUIT_ST7735H_

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -1,3 +1,6 @@
+#ifndef _ADAFRUIT_ST7789H_
+#define _ADAFRUIT_ST7789H_
+
 #include "Adafruit_ST77xx.h"
 
 /// Subclass of ST77XX type display for ST7789 TFT Driver
@@ -36,3 +39,5 @@ class Adafruit_ST7789 : public Adafruit_ST77xx {
  private:
 
 };
+
+#endif // _ADAFRUIT_ST7789H_


### PR DESCRIPTION
Added include guards to Adafruit_ST7735.h and Adafruit_ST7789.h. I tested these changes with the Arduino IDE version 1.8.7 (Linux x64).