### PR TITLE
Add support for Waveshare 1.8" LCD and clones

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -230,6 +230,9 @@ void Adafruit_ST7735::initR(uint8_t options) {
     displayInit(Rcmd2green160x80);
     _colstart = 24;
     _rowstart = 0;
+  } else if(options == INITR_WAVESHARE) {
+	_colstart = 2;
+    _rowstart = 1;
   } else {
     // colstart, rowstart left at default '0' values
     displayInit(Rcmd2red);
@@ -237,7 +240,7 @@ void Adafruit_ST7735::initR(uint8_t options) {
   displayInit(Rcmd3);
 
   // Black tab, change MADCTL color filter
-  if((options == INITR_BLACKTAB) || (options == INITR_MINI160x80)) {
+  if((options == INITR_BLACKTAB) || (options == INITR_MINI160x80) || (options == INITR_WAVESHARE)) {
     startWrite();
     writeCommand(ST77XX_MADCTL);
     spiWrite(0xC0);

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -13,6 +13,7 @@
 #define INITR_144GREENTAB 0x01
 #define INITR_MINI160x80  0x04
 #define INITR_HALLOWING   0x05
+#define INITR_WAVESHARE   0x08
 
 // Some register settings
 #define ST7735_MADCTL_BGR 0x08

--- a/README.txt
+++ b/README.txt
@@ -6,8 +6,10 @@ This is a library for several Adafruit displays based on ST77* drivers.
     ----> https://www.adafruit.com/product/802
   The 1.44" TFT breakout
     ----> https://www.adafruit.com/product/2088
-  as well as Adafruit raw 1.8" TFT display
-    ----> http://www.adafruit.com/products/618
+  Adafruit raw 1.8" TFT display
+  ----> http://www.adafruit.com/products/618
+  as well as the Waveshare TFT LCD
+    ----> https://www.waveshare.com/1.8inch-lcd-module.htm
  
 Check out the links above for our tutorials and wiring diagrams.
 These displays use SPI to communicate, 4 or 5 pins are required to

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -7,8 +7,10 @@
     ----> https://www.adafruit.com/product/802
   The 1.44" TFT breakout
     ----> https://www.adafruit.com/product/2088
-  as well as Adafruit raw 1.8" TFT display
+  Adafruit raw 1.8" TFT display
     ----> http://www.adafruit.com/products/618
+  as well as the Waveshare TFT LCD
+    ----> https://www.waveshare.com/1.8inch-lcd-module.htm
 
   Check out the links above for our tutorials and wiring diagrams.
   These displays use SPI to communicate, 4 or 5 pins are required to
@@ -72,6 +74,8 @@ void setup(void) {
 #else
   // Use this initializer if using a 1.8" TFT screen:
   tft.initR(INITR_BLACKTAB);      // Init ST7735S chip, black tab
+  // If initializer above works, but the screen is 2 rows and 1 column off on the top and right sides - use this one (uncomment):
+  //tft.initR(INITR_WAVESHARE);   // Init ST7735S chip, black tab, offset 2 rows, 1 column (Waveshare LCD)
 
   // OR use this initializer (uncomment) if using a 1.44" TFT:
   //tft.initR(INITR_144GREENTAB); // Init ST7735R chip, green tab

--- a/examples/rotationtest/rotationtest.ino
+++ b/examples/rotationtest/rotationtest.ino
@@ -7,8 +7,10 @@ The 1.8" TFT shield
   ----> https://www.adafruit.com/product/802
 The 1.44" TFT breakout
   ----> https://www.adafruit.com/product/2088
-as well as Adafruit raw 1.8" TFT display
+Adafruit raw 1.8" TFT display
   ----> http://www.adafruit.com/products/618
+as well as the Waveshare TFT LCD
+  ----> https://www.waveshare.com/1.8inch-lcd-module.htm
 
   Check out the links above for our tutorials and wiring diagrams
   These displays use SPI to communicate, 4 or 5 pins are required to
@@ -54,6 +56,8 @@ void setup(void) {
 
   // Use this initializer if you're using a 1.8" TFT
   tft.initR(INITR_BLACKTAB);   // initialize a ST7735S chip, black tab
+  // If initializer above works, but the screen is 2 rows and 1 column off on the top and right sides - use this one (uncomment):
+  //tft.initR(INITR_WAVESHARE);   // initialize a ST7735S chip, black tab, offset 2 rows, 1 column (Waveshare LCD)
 
   // Use this initializer (uncomment) if you're using a 1.44" TFT
   //tft.initR(INITR_144GREENTAB);   // initialize a ST7735S chip, black tab

--- a/examples/spitftbitmap/spitftbitmap.ino
+++ b/examples/spitftbitmap/spitftbitmap.ino
@@ -7,8 +7,10 @@ The 1.8" TFT shield
   ----> https://www.adafruit.com/product/802
 The 1.44" TFT breakout
   ----> https://www.adafruit.com/product/2088
-as well as Adafruit raw 1.8" TFT display
+Adafruit raw 1.8" TFT display
   ----> http://www.adafruit.com/products/618
+as well as the Waveshare TFT LCD
+  ----> https://www.waveshare.com/1.8inch-lcd-module.htm
 
   Check out the links above for our tutorials and wiring diagrams
   These displays use SPI to communicate, 4 or 5 pins are required to
@@ -59,6 +61,8 @@ void setup(void) {
 
   // Use this initializer if you're using a 1.8" TFT
   tft.initR(INITR_BLACKTAB);
+  // If initializer above works, but the screen is 2 rows and 1 column off on the top and right sides - use this one (uncomment):
+  //tft.initR(INITR_WAVESHARE);
 
   // Use this initializer (uncomment) if you're using a 1.44" TFT
   //tft.initR(INITR_144GREENTAB);


### PR DESCRIPTION
This adds support for displays which work when initialized as Black Tab, but are 2 rows and 1 column off. 
Labeled as Waveshare, because other displays that have this issue are unbranded Chinese clones. 

Fixes the specific case of #66 