### PR TITLE
Correct CASET for 160x80 (0x7F -> 0x4F) (fixes #78)

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -176,7 +176,7 @@ static const uint8_t PROGMEM
     2,                              //  2 commands in list:
     ST77XX_CASET,   4,              //  1: Column addr set, 4 args, no delay:
       0x00, 0x00,                   //     XSTART = 0
-      0x00, 0x7F,                   //     XEND = 79
+      0x00, 0x4F,                   //     XEND = 79
     ST77XX_RASET,   4,              //  2: Row addr set, 4 args, no delay:
       0x00, 0x00,                   //     XSTART = 0
       0x00, 0x9F },                 //     XEND = 159


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

I changed one line to correct a number that was incorrect.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

None

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I've tested the 0x4F value with my Rust driver and got a nice happy crab.


