### PR TITLE
Added pin definitions for Feather Huzzah32 to examples

### DIFF
--- a/examples/displayOnOffTest/displayOnOffTest.ino
+++ b/examples/displayOnOffTest/displayOnOffTest.ino
@@ -27,21 +27,6 @@
   #define TFT_RST        15
   #define TFT_DC         32
 
-#elif defined(ESP32)
-  #define TFT_CS         5
-  #define TFT_RST        22 
-  #define TFT_DC         21
-  //
-  // define not needed for all pins; reference for ESP32 physical pins connections to VSPI:
-  // SDA  GPIO23 aka VSPI MOSI
-  // SCLK GPIO18 aka SCK aka VSPI SCK
-  // D/C  GPIO21 aka A0 (also I2C SDA)
-  // RST  GPIO22 aka RESET (also I2C SCL)
-  // CS   GPIO5  aka chip select
-  // LED  3.3V
-  // VCC  5V
-  // GND - GND
-
 #elif defined(ESP8266)
   #define TFT_CS         4
   #define TFT_RST        16                                            

--- a/examples/displayOnOffTest/displayOnOffTest.ino
+++ b/examples/displayOnOffTest/displayOnOffTest.ino
@@ -22,6 +22,11 @@
   #define TFT_DC        38 // Display data/command select
   #define TFT_BACKLIGHT  7 // Display backlight pin
 
+#elif defined(ARDUINO_FEATHER_ESP32) // Feather Huzzah32
+  #define TFT_CS         14
+  #define TFT_RST        15
+  #define TFT_DC         32
+
 #elif defined(ESP32)
   #define TFT_CS         5
   #define TFT_RST        22 

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -40,21 +40,6 @@
   #define TFT_RST        15
   #define TFT_DC         32
 
-#elif defined(ESP32)
-  #define TFT_CS         5
-  #define TFT_RST        22 
-  #define TFT_DC         21
-  //
-  // define not needed for all pins; reference for ESP32 physical pins connections to VSPI:
-  // SDA  GPIO23 aka VSPI MOSI
-  // SCLK GPIO18 aka SCK aka VSPI SCK
-  // D/C  GPIO21 aka A0 (also I2C SDA)
-  // RST  GPIO22 aka RESET (also I2C SCL)
-  // CS   GPIO5  aka chip select
-  // LED  3.3V
-  // VCC  5V
-  // GND - GND
-  //
 #elif defined(ESP8266)
   #define TFT_CS         4
   #define TFT_RST        16                                            

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -35,7 +35,12 @@
 #include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
 #include <SPI.h>
 
-#if defined(ESP32)
+#if defined(ARDUINO_FEATHER_ESP32) // Feather Huzzah32
+  #define TFT_CS         14
+  #define TFT_RST        15
+  #define TFT_DC         32
+
+#elif defined(ESP32)
   #define TFT_CS         5
   #define TFT_RST        22 
   #define TFT_DC         21

--- a/examples/rotationtest/rotationtest.ino
+++ b/examples/rotationtest/rotationtest.ino
@@ -64,21 +64,6 @@ The HalloWing M4 Express
   #define TFT_RST        15
   #define TFT_DC         32
 
-#elif defined(ESP32)
-  #define TFT_CS         5
-  #define TFT_RST        22 
-  #define TFT_DC         21
-  //
-  // define not needed for all pins; reference for ESP32 physical pins connections to VSPI:
-  // SDA  GPIO23 aka VSPI MOSI
-  // SCLK GPIO18 aka SCK aka VSPI SCK
-  // D/C  GPIO21 aka A0 (also I2C SDA)
-  // RST  GPIO22 aka RESET (also I2C SCL)
-  // CS   GPIO5  aka chip select
-  // LED  3.3V
-  // VCC  5V
-  // GND - GND
-  //
 #elif defined(ESP8266)
   #define TFT_CS         4
   #define TFT_RST        16                                            

--- a/examples/rotationtest/rotationtest.ino
+++ b/examples/rotationtest/rotationtest.ino
@@ -59,6 +59,11 @@ The HalloWing M4 Express
   #define TFT_DC        45 // Display data/command select
   #define TFT_BACKLIGHT 47 // Display backlight pin
 
+#elif defined(ARDUINO_FEATHER_ESP32) // Feather Huzzah32
+  #define TFT_CS         14
+  #define TFT_RST        15
+  #define TFT_DC         32
+
 #elif defined(ESP32)
   #define TFT_CS         5
   #define TFT_RST        22 


### PR DESCRIPTION
Tested with 160x128 display. Chose these pins for consistency with MiniTFT examples. Fixes #98.