### PR TITLE
Removed useless assign

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -113,8 +113,6 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
     _colstart = 0;
     _rowstart = 0;
   }
-  WIDTH = width;
-  HEIGHT = height;
   _width = width;
   _height = height;
 


### PR DESCRIPTION
Removed assignation of Adafruit_GFX parent class' member variables. They are already set in [Adafruit_GFX constructor](https://github.com/adafruit/Adafruit-GFX-Library/blob/master/Adafruit_GFX.cpp#L110).

Will allow to declare "WIDTH" and "HEIGHT" member variables in Adafruit_GFX as const.