### PR TITLE
Using new vars to allow setting WIDTH and HEIGHT to constants

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -113,8 +113,9 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
     _colstart = 0;
     _rowstart = 0;
   }
-  WIDTH = width;
-  HEIGHT = height;
+
+  windowWidth = width;
+  windowHeight = height;
 
   displayInit(generic_st7789);
 
@@ -141,15 +142,15 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
     madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
     _xstart = _colstart;
     _ystart = _rowstart;
-    _width = WIDTH;
-    _height = HEIGHT;
+    _width = windowWidth;
+    _height = windowHeight;
     break;
   case 1:
     madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     _xstart = _rowstart;
     _ystart = _colstart;
-    _height = WIDTH;
-    _width = HEIGHT;
+    _height = windowWidth;
+    _width = windowHeight;
     break;
   case 2:
     madctl = ST77XX_MADCTL_RGB;
@@ -160,8 +161,8 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
       _xstart = 0;
       _ystart = 0;
     }
-    _width = WIDTH;
-    _height = HEIGHT;
+    _width = windowWidth;
+    _height = windowHeight;
     break;
   case 3:
     madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
@@ -172,8 +173,8 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
       _xstart = 0;
       _ystart = 0;
     }
-    _height = WIDTH;
-    _width = HEIGHT;
+    _height = windowWidth;
+    _width = windowHeight;
     break;
   }
 

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -15,6 +15,7 @@ public:
 
   void setRotation(uint8_t m);
   void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
+
 private:
   uint16_t windowWidth;
   uint16_t windowHeight;

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -15,6 +15,9 @@ public:
 
   void setRotation(uint8_t m);
   void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
+private:
+  uint16_t windowWidth;
+  uint16_t windowHeight;
 };
 
 #endif // _ADAFRUIT_ST7789H_


### PR DESCRIPTION
When I applied a fix so that the tft.width() and tft.height() functions returned the correct values in #111 , I did it in more of a quick fix manner and just changed the WIDTH and HEIGHT parameters. However, this isthe only place they are ever changed and in order for https://github.com/adafruit/Adafruit-GFX-Library/pull/270 to not break this library, this change is needed. I tested using @caternuson's test script from #110 and the dimensions came back correct.