### PR TITLE
Add init method for ST7735S (RGB, 80x160)

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -212,6 +212,22 @@ void Adafruit_ST7735::initB(void) {
 
 /**************************************************************************/
 /*!
+    @brief  Initialization code common to ST7735S displays
+*/
+/**************************************************************************/
+void Adafruit_ST7735::initS() {
+  commonInit(Rcmd1);
+  _height = ST7735_TFTWIDTH_80;
+  _width = ST7735_TFTHEIGHT_160;
+  displayInit(Rcmd2green160x80);
+  _colstart = 24;
+  _rowstart = 0;
+  displayInit(Rcmd3);
+  setRotation(0);
+}
+
+/**************************************************************************/
+/*!
     @brief  Initialization code common to all ST7735R displays
     @param  options  Tab color from adafruit purchase
 */

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -59,6 +59,7 @@ public:
   // Differences between displays (usu. identified by colored tab on
   // plastic overlay) are odd enough that we need to do this 'by hand':
   void initB(void);                             // for ST7735B displays
+  void initS(void);                             // for ST7735S displays
   void initR(uint8_t options = INITR_GREENTAB); // for ST7735R
 
   void setRotation(uint8_t m);


### PR DESCRIPTION
- I have added an `initS()` method that initializes ST7735S displays (RGB, 80x160). As far as I know, Adafruit doesn't sell this kind display, but this is very popular library for st77xx family, so might as well have it here.  

- Given that there are several variations of ST7735R display, I can not disregard the possibility of the same being the case for -S displays. This method at least works for the one I have, it looks like this: 

<img width="345" alt="image" src="https://user-images.githubusercontent.com/4255635/84144604-0d8e0580-aa48-11ea-9bc5-d6ff3f661f57.png">
