### PR TITLE
sleep method added

### DIFF
--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -238,6 +238,16 @@ void Adafruit_ST77xx::enableTearing(boolean enable) {
   sendCommand(enable ? ST77XX_TEON : ST77XX_TEOFF);
 }
 
+/**************************************************************************/
+/*!
+ @brief  Change whether sleep mode is on or off
+ @param  enable True if you want sleep mode ON, false OFF
+ */
+/**************************************************************************/
+void Adafruit_ST77xx::enableSleep(boolean enable) {
+  sendCommand(enable ? ST77XX_SLPIN : ST77XX_SLPOUT);
+}
+
 ////////// stuff not actively being used, but kept for posterity
 /*
 

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -101,6 +101,7 @@ public:
   void setRotation(uint8_t r);
   void enableDisplay(boolean enable);
   void enableTearing(boolean enable);
+  void enableSleep(boolean enable);
 
 protected:
   uint8_t _colstart = 0,   ///< Some displays need this changed to offset


### PR DESCRIPTION
Hi!

ST77xx chip supports a "sleep mode" (the _datasheet_ describes it as "the minimum power consumption mode").
The required opcodes are already present in Adafruit_ST77xx.h:

`#define ST77XX_SLPIN 0x10`
`#define ST77XX_SLPOUT 0x11`

but the `sendCommand()` method is not public so the only way to use them is to create dedicated methods in the library.

I tried to use the same approach of already existing methods (enableDisplay, enableTearing).

This commit also Closes #74 