### PR TITLE
Added missing library dependency

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit ST7735 and ST7789 SPI displays.
 category=Display
 url=https://github.com/adafruit/Adafruit-ST7735-Library
 architectures=*
-depends=Adafruit GFX Library, Adafruit seesaw Library, SD
+depends=Adafruit GFX Library, Adafruit seesaw Library, SD, Adafruit BusIO


### PR DESCRIPTION
When trying to compile a simple project with the library under PlatformIO, I had the following error.

> Verbose mode can be enabled via `-v, --verbose` option
> CONFIGURATION: https://docs.platformio.org/page/boards/atmelavr/uno.html
> PLATFORM: Atmel AVR (3.3.0) > Arduino Uno
> HARDWARE: ATMEGA328P 16MHz, 2KB RAM, 31.50KB Flash
> DEBUG: Current (avr-stub) On-board (avr-stub, simavr)
> PACKAGES:
>  \- framework-arduino-avr 5.1.0
>  \- toolchain-atmelavr 1.70300.191015 (7.3.0)
> LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf
> LDF Modes: Finder ~ chain, Compatibility ~ soft
> Found 10 compatible libraries
> Scanning dependencies...
> Dependency Graph
> |-- \<Adafruit ST7735 and ST7789 Library\> 1.7.2
> |   |-- \<Adafruit GFX Library\> 1.10.7
> |   |   |-- \<SPI\> 1.0
> |   |-- \<SPI\> 1.0
> |-- \<Adafruit GFX Library\> 1.10.7
> |   |-- \<SPI\> 1.0
> |-- \<SPI\> 1.0
> Building in release mode
> Compiling .pio\build\uno\libc43\Adafruit GFX Library\Adafruit_GrayOLED.cpp.o
> In file included from .pio\libdeps\uno\Adafruit GFX Library\Adafruit_GrayOLED.cpp:20:0:
> .pio\libdeps\uno\Adafruit GFX Library\Adafruit_GrayOLED.h:30:10: fatal error: Adafruit_I2CDevice.h: No such file or directory