### PR TITLE
Add screen flip function for ST7789

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -134,36 +134,67 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
 */
 /**************************************************************************/
 void Adafruit_ST7789::setRotation(uint8_t m) {
+  setRotation(m, false);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Set origin of (0,0) and orientation of TFT display
+    @param  m  The index for rotation, from 0-3 inclusive
+    @param  flip  Flip the screen horizontally
+*/
+/**************************************************************************/
+void Adafruit_ST7789::setRotation(uint8_t m, bool flip) {
   uint8_t madctl = 0;
 
   rotation = m & 3; // can't be higher than 3
 
   switch (rotation) {
-  case 0:
-    madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
+  case 0:                      // 180deg   ST77XX_ROTATE_BOTTOM
+    if (flip) {
+      madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
+    } else {
+      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
+    }
     _xstart = _colstart;
     _ystart = _rowstart;
     _width = windowWidth;
     _height = windowHeight;
     break;
-  case 1:
-    madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
-    _xstart = _rowstart;
-    _ystart = _colstart;
+  case 1:                      // 270deg   ST77XX_ROTATE_RIGHT
+    if (flip) {
+      madctl = ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+      _xstart = _rowstart2;
+      _ystart = _colstart2;
+    } else {
+      madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+      _xstart = _rowstart;
+      _ystart = _colstart;
+    }
     _height = windowWidth;
     _width = windowHeight;
     break;
-  case 2:
-    madctl = ST77XX_MADCTL_RGB;
+  case 2:                      // 0deg     ST77XX_ROTATE_NONE
+    if (flip) {
+      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_RGB;
+    } else {
+      madctl = ST77XX_MADCTL_RGB;
+    }
     _xstart = _colstart2;
     _ystart = _rowstart2;
     _width = windowWidth;
     _height = windowHeight;
     break;
-  case 3:
-    madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
-    _xstart = _rowstart2;
-    _ystart = _colstart2;
+  case 3:                      // 90deg    ST77XX_ROTATE_RIGHT
+    if (flip) {
+      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+      _xstart = _rowstart;
+      _ystart = _colstart;
+    } else {
+      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+      _xstart = _rowstart2;
+      _ystart = _colstart2;
+    }
     _height = windowWidth;
     _width = windowHeight;
     break;

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -3,6 +3,19 @@
 
 #include "Adafruit_ST77xx.h"
 
+// Define the screen rotation position in a clockwise direction
+//
+//        NONE
+//  LEFT   +    RIGHT
+//       BOTTOM
+//
+#define ST77XX_ROTATE_NONE              2
+#define ST77XX_ROTATE_RIGHT             1
+#define ST77XX_ROTATE_LEFT              3
+#define ST77XX_ROTATE_BOTTOM            0
+// Flip the screen horizontally, useful in some applications that use mirrors.
+#define ST77XX_FLIP_HORIZONTAL          true
+
 /// Subclass of ST77XX type display for ST7789 TFT Driver
 class Adafruit_ST7789 : public Adafruit_ST77xx {
 public:
@@ -14,6 +27,7 @@ public:
 #endif // end !ESP8266
 
   void setRotation(uint8_t m);
+  void setRotation(uint8_t r, bool flip);
   void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
 
 protected:


### PR DESCRIPTION
Screen flip function was useful in some applications that use mirrors.

Add flip flag added to  setRotation() function.

`void setRotation(uint8_t r, bool flip);`

Only tested on 1.3" TFT screen with 7 pins.

![1 3寸TFT7针](https://user-images.githubusercontent.com/47002/128205328-00a087a9-90c1-4e90-baec-079e3f798171.jpeg)
