### PR TITLE
Support for stm32duino 

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -11,8 +11,8 @@
     @param  sclk  SPI Clock pin #
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
-Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
-                                 int8_t rst)
+Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk,
+                                 int16_t rst)
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, mosi,
                       sclk, rst) {}
 
@@ -22,7 +22,7 @@ Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
     @param  dc   Data/Command pin #
     @param  rst  Reset pin # (optional, pass -1 if unused)
 */
-Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst)
+Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst)
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -33,8 +33,8 @@ Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst)
     @param  dc        Data/Command pin #
     @param  rst       Reset pin # (optional, pass -1 if unused)
 */
-Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc,
-                                 int8_t rst)
+Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc,
+                                 int16_t rst)
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, spiClass, cs,
                       dc, rst) {}
 #endif // end !ESP8266

--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -11,8 +11,13 @@
     @param  sclk  SPI Clock pin #
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
+#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk,
                                  int16_t rst)
+#else
+Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
+                                 int8_t rst)
+#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, mosi,
                       sclk, rst) {}
 
@@ -22,7 +27,11 @@ Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t s
     @param  dc   Data/Command pin #
     @param  rst  Reset pin # (optional, pass -1 if unused)
 */
+#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst)
+#else
+Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst)
+#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -33,8 +42,13 @@ Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst)
     @param  dc        Data/Command pin #
     @param  rst       Reset pin # (optional, pass -1 if unused)
 */
+#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc,
                                  int16_t rst)
+#else
+Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc,
+                                 int8_t rst)
+#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, spiClass, cs,
                       dc, rst) {}
 #endif // end !ESP8266

--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -11,13 +11,8 @@
     @param  sclk  SPI Clock pin #
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
-#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk,
                                  int16_t rst)
-#else
-Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
-                                 int8_t rst)
-#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, mosi,
                       sclk, rst) {}
 
@@ -27,11 +22,7 @@ Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
     @param  dc   Data/Command pin #
     @param  rst  Reset pin # (optional, pass -1 if unused)
 */
-#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst)
-#else
-Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst)
-#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -42,13 +33,8 @@ Adafruit_ST7735::Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst)
     @param  dc        Data/Command pin #
     @param  rst       Reset pin # (optional, pass -1 if unused)
 */
-#if defined(ARDUINO_ARCH_STM32) 
 Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc,
                                  int16_t rst)
-#else
-Adafruit_ST7735::Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc,
-                                 int8_t rst)
-#endif
     : Adafruit_ST77xx(ST7735_TFTWIDTH_128, ST7735_TFTHEIGHT_160, spiClass, cs,
                       dc, rst) {}
 #endif // end !ESP8266

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -50,17 +50,11 @@
 /// Subclass of ST77XX for ST7735B and ST7735R TFT Drivers:
 class Adafruit_ST7735 : public Adafruit_ST77xx {
 public:
-#if defined(ARDUINO_ARCH_STM32) 
   Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk, int16_t rst);
   Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst);
-  Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc, int16_t rst);
-#else
-  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk, int8_t rst);
-  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst);
 #if !defined(ESP8266)
-  Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
+  Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc, int16_t rst);
 #endif // end !ESP8266
-#endif //end ARDUINO_ARCH_STM32
 
   // Differences between displays (usu. identified by colored tab on
   // plastic overlay) are odd enough that we need to do this 'by hand':

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -50,10 +50,10 @@
 /// Subclass of ST77XX for ST7735B and ST7735R TFT Drivers:
 class Adafruit_ST7735 : public Adafruit_ST77xx {
 public:
-  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk, int8_t rst);
-  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst);
+  Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk, int16_t rst);
+  Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst);
 #if !defined(ESP8266)
-  Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
+  Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc, int16_t rst);
 #endif // end !ESP8266
 
   // Differences between displays (usu. identified by colored tab on

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -50,11 +50,17 @@
 /// Subclass of ST77XX for ST7735B and ST7735R TFT Drivers:
 class Adafruit_ST7735 : public Adafruit_ST77xx {
 public:
+#if defined(ARDUINO_ARCH_STM32) 
   Adafruit_ST7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sclk, int16_t rst);
   Adafruit_ST7735(int16_t cs, int16_t dc, int16_t rst);
-#if !defined(ESP8266)
   Adafruit_ST7735(SPIClass *spiClass, int16_t cs, int16_t dc, int16_t rst);
+#else
+  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk, int8_t rst);
+  Adafruit_ST7735(int8_t cs, int8_t dc, int8_t rst);
+#if !defined(ESP8266)
+  Adafruit_ST7735(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
 #endif // end !ESP8266
+#endif //end ARDUINO_ARCH_STM32
 
   // Differences between displays (usu. identified by colored tab on
   // plastic overlay) are odd enough that we need to do this 'by hand':

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -45,9 +45,15 @@
     @param  miso  SPI MISO pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
+#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
                                  int16_t mosi, int16_t sclk, int16_t rst,
                                  int16_t miso)
+#else
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
+                                 int8_t mosi, int8_t sclk, int8_t rst,
+                                 int8_t miso)
+#endif
     : Adafruit_SPITFT(w, h, cs, dc, mosi, sclk, rst, miso) {}
 
 /**************************************************************************/
@@ -60,8 +66,13 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
+#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
                                  int16_t rst)
+#else
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
+                                 int8_t rst)
+#endif
     : Adafruit_SPITFT(w, h, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -76,8 +87,13 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
+#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
                                  int16_t cs, int16_t dc, int16_t rst)
+#else
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
+                                 int8_t cs, int8_t dc, int8_t rst)
+#endif                                 
     : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
 #endif // end !ESP8266
 

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -45,15 +45,9 @@
     @param  miso  SPI MISO pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
                                  int16_t mosi, int16_t sclk, int16_t rst,
                                  int16_t miso)
-#else
-Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
-                                 int8_t mosi, int8_t sclk, int8_t rst,
-                                 int8_t miso)
-#endif
     : Adafruit_SPITFT(w, h, cs, dc, mosi, sclk, rst, miso) {}
 
 /**************************************************************************/
@@ -66,13 +60,8 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
                                  int16_t rst)
-#else
-Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
-                                 int8_t rst)
-#endif
     : Adafruit_SPITFT(w, h, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -87,13 +76,8 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-#if defined(ARDUINO_ARCH_STM32)
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
                                  int16_t cs, int16_t dc, int16_t rst)
-#else
-Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
-                                 int8_t cs, int8_t dc, int8_t rst)
-#endif                                 
     : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
 #endif // end !ESP8266
 

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -45,9 +45,9 @@
     @param  miso  SPI MISO pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
-                                 int8_t mosi, int8_t sclk, int8_t rst,
-                                 int8_t miso)
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
+                                 int16_t mosi, int16_t sclk, int16_t rst,
+                                 int16_t miso)
     : Adafruit_SPITFT(w, h, cs, dc, mosi, sclk, rst, miso) {}
 
 /**************************************************************************/
@@ -60,8 +60,8 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
     @param  rst   Reset pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
-                                 int8_t rst)
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t cs, int16_t dc,
+                                 int16_t rst)
     : Adafruit_SPITFT(w, h, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -77,7 +77,7 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
 */
 /**************************************************************************/
 Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
-                                 int8_t cs, int8_t dc, int8_t rst)
+                                 int16_t cs, int16_t dc, int16_t rst)
     : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
 #endif // end !ESP8266
 

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -88,13 +88,13 @@
 /// Subclass of SPITFT for ST77xx displays (lots in common!)
 class Adafruit_ST77xx : public Adafruit_SPITFT {
 public:
-  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI,
-                  int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t CS, int8_t RS,
-                  int8_t RST = -1);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t _CS, int16_t _DC, int16_t _MOSI,
+                  int16_t _SCLK, int16_t _RST = -1, int16_t _MISO = -1);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t CS, int16_t RS,
+                  int16_t RST = -1);
 #if !defined(ESP8266)
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t CS,
-                  int8_t RS, int8_t RST = -1);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int16_t CS,
+                  int16_t RS, int16_t RST = -1);
 #endif // end !ESP8266
 
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -88,15 +88,23 @@
 /// Subclass of SPITFT for ST77xx displays (lots in common!)
 class Adafruit_ST77xx : public Adafruit_SPITFT {
 public:
+#if defined(ARDUINO_ARCH_STM32)
   Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t _CS, int16_t _DC, int16_t _MOSI,
                   int16_t _SCLK, int16_t _RST = -1, int16_t _MISO = -1);
   Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t CS, int16_t RS,
                   int16_t RST = -1);
-#if !defined(ESP8266)
   Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int16_t CS,
-                  int16_t RS, int16_t RST = -1);
+                  int16_t RS, int16_t RST = -1);                  
+#else
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI,
+                  int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t CS, int8_t RS,
+                  int8_t RST = -1);     
+#if !defined(ESP8266)
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t CS,
+                  int8_t RS, int8_t RST = -1);
 #endif // end !ESP8266
-
+#endif // end ARDUINO_ARCH_STM32
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void setRotation(uint8_t r);
   void enableDisplay(boolean enable);

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -88,23 +88,15 @@
 /// Subclass of SPITFT for ST77xx displays (lots in common!)
 class Adafruit_ST77xx : public Adafruit_SPITFT {
 public:
-#if defined(ARDUINO_ARCH_STM32)
   Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t _CS, int16_t _DC, int16_t _MOSI,
                   int16_t _SCLK, int16_t _RST = -1, int16_t _MISO = -1);
   Adafruit_ST77xx(uint16_t w, uint16_t h, int16_t CS, int16_t RS,
                   int16_t RST = -1);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int16_t CS,
-                  int16_t RS, int16_t RST = -1);                  
-#else
-  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI,
-                  int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t CS, int8_t RS,
-                  int8_t RST = -1);     
 #if !defined(ESP8266)
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t CS,
-                  int8_t RS, int8_t RST = -1);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int16_t CS,
+                  int16_t RS, int16_t RST = -1);
 #endif // end !ESP8266
-#endif // end ARDUINO_ARCH_STM32
+
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void setRotation(uint8_t r);
   void enableDisplay(boolean enable);


### PR DESCRIPTION
I changed types of variables used to specify IO pins such as DC, CS, RST, MISO, CLK from int8_t to int16_t because for example on bluepill PA4 = 196, PB0 = 200, PB1 = 201 and such numbers cant fit into int8_t (that holds +-127 because of sign) and this cause the library doesnt work with stm32duino / bluepill (the RST/DC/CS pins does not output any signal to LCD). It works perfectly with int16_t. 

Tested using https://github.com/stm32duino/Arduino_Core_STM32 version 2.1.0

the Adafruit-GFX-Library needs to be modified in similar way, will put another pull request for this in a moment

not tested with other platforms like AVR or ESP because I dont have such HW just now, tested using stm32f103c8 bluepill, also tested that the "graphic test" example compiles wo errors with avr / esp8266 board selected