### PR TITLE
For the 135x240 display, the offset was incorrect by 1 pixel

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -115,7 +115,7 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
   } else if (width == 135 && height == 240) {
     // 1.14" display
     _rowstart = _rowstart2 = (int)((320 - height + 1) / 2);
-    _colstart2 = _colstart = (int)((240 - width + 1) / 2);
+    _colstart2 = _colstart = (int)((240 - width) / 2);
   } else {
     // 1.3", 1.54", and 2.0" displays
     _rowstart = (320 - height);


### PR DESCRIPTION
This change only modifies the offsets for rendering on the 1.13" 135x240 LCD (https://www.adafruit.com/product/4383)

Prior to this change, if you did this:
tft.fillScreen(ST77XX_WHITE);
tft.setRotatation(1);
tft.fillScreen(ST77XX_BLACK);

you would wind up with the top line (where 'top' is the row of pixels closest to the solder holes) being white. It just looks like the offset was off by one, thanks to an odd width value.

Please let me know if there's any specific testing/validation you want. I'm running this on a Teensy 4.0 at 600MHz, with an SPI clock set to 60MHz. I've validated the issue is consistent across much slower clock frequencies for both the MPU and the SPI bus.