### PR TITLE
Fixed (and validated at all orientations) the display window calculation for 135x240 screen

### DIFF
--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -115,8 +115,11 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
   } else if (width == 135 && height == 240) {
     // 1.14" display
     _rowstart = _rowstart2 = (int)((320 - height) / 2);
-    _colstart = (int)((240 - width) / 2);
-    _colstart2 = (int)((240 - width + 1) / 2);
+    // This is the only device currently supported device that has different
+    // values for _colstart & _colstart2. You must ensure that the extra
+    // pixel lands in _colstart and not in _colstart2
+    _colstart = (int)((240 - width + 1) / 2);
+    _colstart2 = (int)((240 - width) / 2);
   } else {
     // 1.3", 1.54", and 2.0" displays
     _rowstart = (320 - height);
@@ -153,7 +156,7 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
   case 1:
     madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     _xstart = _rowstart;
-    _ystart = _colstart;
+    _ystart = _colstart2;
     _height = windowWidth;
     _width = windowHeight;
     break;
@@ -167,7 +170,7 @@ void Adafruit_ST7789::setRotation(uint8_t m) {
   case 3:
     madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     _xstart = _rowstart2;
-    _ystart = _colstart2;
+    _ystart = _colstart;
     _height = windowWidth;
     _width = windowHeight;
     break;


### PR DESCRIPTION
Fixed over lunch today, when I probably should have been doing other things...

This makes the ST7789 code work properly for Adafruit's 1.13" 135x240 display at all orientations. Previously, it was off-by-1 in landscape (1) and inverted portrait (2) orientations. If I followed the code properly, this is the only display that should behave differently at different orientations, there's explicit code to deal with it, but it was wrong because _colstart and _colstart2 were always the same value anyway (It looks like a [previous change](https://github.com/adafruit/Adafruit-ST7735-Library/commit/bcc7e08752c880cd6d7ec9fe34ea9224021704f8) tried to fix it, but wound up only fixing part of the issue)

If you want to test the code out elsewhere, here's my [test repo](https://github.com/kevinfrei/ST7789_135_240_test) just grab the [test.cpp](https://raw.githubusercontent.com/kevinfrei/ST7789_135_240_test/main/test.cpp) file, rename it `test.ino`, set the pin numbers properly, and use it in Arduino. The code prints the orientation, while clearing the screen to blue in orientation 0, then setting the orientation and clearing it to black (so you *shouldn't* see any blue, but you do for 1 & 2) and the other clears the screen to green in orientation 0, then fills a centered rect black 2 pixels narrower and shorter than the screen, so you should see a  green rectangle all the way around the screen (which you don't for 1 & 2 again).

You can see it in action [before here](https://1drv.ms/v/s!Ap9iqQ7FiN9Qhtlj1my6JwZ9xeEQ8Q) and [after here](https://1drv.ms/v/s!Ap9iqQ7FiN9QhtlkkxcP4woMwMZUNg).
