### PR TITLE
Update graphics tests.

### DIFF
--- a/examples/graphicstest_feather_esp32s2_tft/graphicstest_feather_esp32s2_tft.ino
+++ b/examples/graphicstest_feather_esp32s2_tft/graphicstest_feather_esp32s2_tft.ino
@@ -25,7 +25,7 @@ float p = 3.1415926;
 
 void setup(void) {
   Serial.begin(9600);
-  Serial.print(F("Hello! ST77xx TFT Test"));
+  Serial.print(F("Hello! Feather TFT Test"));
 
   // turn on backlite
   pinMode(TFT_BACKLITE, OUTPUT);
@@ -283,20 +283,20 @@ void tftPrintTest() {
 void mediabuttons() {
   // play
   tft.fillScreen(ST77XX_BLACK);
-  tft.fillRoundRect(25, 10, 78, 60, 8, ST77XX_WHITE);
-  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_RED);
+  tft.fillRoundRect(25, 5, 78, 60, 8, ST77XX_WHITE);
+  tft.fillTriangle(42, 12, 42, 60, 90, 40, ST77XX_RED);
   delay(500);
   // pause
-  tft.fillRoundRect(25, 90, 78, 60, 8, ST77XX_WHITE);
-  tft.fillRoundRect(39, 98, 20, 45, 5, ST77XX_GREEN);
-  tft.fillRoundRect(69, 98, 20, 45, 5, ST77XX_GREEN);
+  tft.fillRoundRect(25, 70, 78, 60, 8, ST77XX_WHITE);
+  tft.fillRoundRect(39, 78, 20, 45, 5, ST77XX_GREEN);
+  tft.fillRoundRect(69, 78, 20, 45, 5, ST77XX_GREEN);
   delay(500);
   // play color
-  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_BLUE);
+  tft.fillTriangle(42, 12, 42, 60, 90, 40, ST77XX_BLUE);
   delay(50);
   // pause color
-  tft.fillRoundRect(39, 98, 20, 45, 5, ST77XX_RED);
-  tft.fillRoundRect(69, 98, 20, 45, 5, ST77XX_RED);
+  tft.fillRoundRect(39, 78, 20, 45, 5, ST77XX_RED);
+  tft.fillRoundRect(69, 78, 20, 45, 5, ST77XX_RED);
   // play color
-  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_GREEN);
+  tft.fillTriangle(42, 12, 42, 60, 90, 40, ST77XX_GREEN);
 }

--- a/examples/graphicstest_hallowing_m0/graphicstest_hallowing_m0.ino
+++ b/examples/graphicstest_hallowing_m0/graphicstest_hallowing_m0.ino
@@ -37,11 +37,12 @@ float p = 3.1415926;
 
 void setup(void) {
   Serial.begin(9600);
-  Serial.print(F("Hello! ST77xx TFT Test"));
+  Serial.print(F("Hello! HalloWing TFT Test"));
 
-  tft.initR(INITR_HALLOWING);        // Initialize HalloWing-oriented screen
   pinMode(TFT_BACKLIGHT, OUTPUT);
   digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
+
+  tft.initR(INITR_HALLOWING);        // Initialize HalloWing-oriented screen
 
   Serial.println(F("Initialized"));
 

--- a/examples/graphicstest_hallowing_m4/graphicstest_hallowing_m4.ino
+++ b/examples/graphicstest_hallowing_m4/graphicstest_hallowing_m4.ino
@@ -18,7 +18,7 @@
 #include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
 #include <SPI.h>
 
-#define TFT_CS        44 // PyBadge/PyGamer display control pins: chip select
+#define TFT_CS        44 // HalloWing M4 display control pins: chip select
 #define TFT_RST       46 // Display reset
 #define TFT_DC        45 // Display data/command select
 #define TFT_BACKLIGHT 47 // Display backlight pin
@@ -38,11 +38,12 @@ float p = 3.1415926;
 
 void setup(void) {
   Serial.begin(9600);
-  Serial.print(F("Hello! ST77xx TFT Test"));
+  Serial.print(F("Hello! HalloWing TFT Test"));
 
-  tft.init(240, 240);                // Initialize ST7789 screen
   pinMode(TFT_BACKLIGHT, OUTPUT);
   digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
+
+  tft.init(240, 240); // Initialize ST7789 screen
 
   Serial.println(F("Initialized"));
 

--- a/examples/graphicstest_pybadge_pygamer/graphicstest_pybadge_pygamer.ino
+++ b/examples/graphicstest_pybadge_pygamer/graphicstest_pybadge_pygamer.ino
@@ -40,12 +40,13 @@ float p = 3.1415926;
 
 void setup(void) {
   Serial.begin(9600);
-  Serial.print(F("Hello! ST77xx TFT Test"));
+  Serial.print(F("Hello! PyBadge/PyGamer TFT Test"));
+
+  pinMode(TFT_BACKLIGHT, OUTPUT);
+  digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
 
   tft.initR(INITR_BLACKTAB);        // Initialize ST7735R screen
   tft.setRotation(1);
-  pinMode(TFT_BACKLIGHT, OUTPUT);
-  digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
 
   Serial.println(F("Initialized"));
 

--- a/examples/graphicstest_tft_gizmo/graphicstest_tft_gizmo.ino
+++ b/examples/graphicstest_tft_gizmo/graphicstest_tft_gizmo.ino
@@ -48,12 +48,13 @@ float p = 3.1415926;
 
 void setup(void) {
   Serial.begin(9600);
-  Serial.print(F("Hello! ST77xx TFT Test"));
+  Serial.print(F("Hello! Gizmo TFT Test"));
 
-  tft.init(240, 240);                // Init ST7789 240x240
-  tft.setRotation(2);  
   pinMode(TFT_BACKLIGHT, OUTPUT);
   digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
+
+  tft.init(240, 240);                // Init ST7789 240x240
+  tft.setRotation(2);
 
   Serial.println(F("Initialized"));
 


### PR DESCRIPTION
Tweaked the end of the Feather TFT graphics test so that the "play" and "pause" buttons both fit on the display.

Tweaked initialisation order on the other files so they are consistent with the Feather TFT init order so that when they are eventually used in the new built-in TFT template, the init explanation order fits the example order. (i.e. create tft instance, turn on backlight, turn on TFT power if applicable, init display and rotation.)