### PR TITLE
Added support for WaveShare-like modules (greentab offsets with blacktab colors-yellowtab?)

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -241,7 +241,7 @@ void Adafruit_ST7735::initR(uint8_t options) {
   displayInit(Rcmd3);
 
   // Black tab, change MADCTL color filter
-  if ((options == INITR_BLACKTAB) || (options == INITR_MINI160x80)) {
+  if ((options == INITR_BLACKTAB) || (options == INITR_GREENTAB_WS) || (options == INITR_MINI160x80)) {
     uint8_t data = 0xC0;
     sendCommand(ST77XX_MADCTL, &data, 1);
   }
@@ -277,7 +277,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
 
   switch (rotation) {
   case 0:
-    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_GREENTAB_WS) || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST7735_MADCTL_BGR;
@@ -297,7 +297,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 1:
-    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_GREENTAB_WS) || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
@@ -317,7 +317,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _xstart = _rowstart;
     break;
   case 2:
-    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_GREENTAB_WS) || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_RGB;
     } else {
       madctl = ST7735_MADCTL_BGR;
@@ -337,7 +337,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 3:
-    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_GREENTAB_WS) || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;

--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -277,7 +277,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
 
   switch (rotation) {
   case 0:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST7735_MADCTL_BGR;
@@ -297,7 +297,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 1:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
@@ -317,7 +317,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _xstart = _rowstart;
     break;
   case 2:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_RGB;
     } else {
       madctl = ST7735_MADCTL_BGR;
@@ -337,7 +337,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 3:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
+    if ((tabcolor == INITR_BLACKTAB) || INITR_GREENTAB_WS || (tabcolor == INITR_MINI160x80)) {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
     } else {
       madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -13,6 +13,7 @@
 #define INITR_144GREENTAB 0x01
 #define INITR_MINI160x80 0x04
 #define INITR_HALLOWING 0x05
+#define INITR_GREENTAB_WS INITR_GREENTAB
 
 // Some register settings
 #define ST7735_MADCTL_BGR 0x08


### PR DESCRIPTION
Added simple definition for [WaveShare version module](https://www.waveshare.com/wiki/1.8inch_LCD_Module). They use GREENTAB offsets, but BLACKTAB colors (someone referred to them as YELLOWTAB?)
Random cheapo modules seem to use this scheme as well.

*Initialize display with INITR_GREENTAB_WS, simple as that

