### PR TITLE
Support the new Arduino UNO-R4 boards

### DIFF
--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -24,9 +24,11 @@
 
 #include "Adafruit_ST77xx.h"
 #include <limits.h>
-#ifndef ARDUINO_STM32_FEATHER
+#if !defined(ARDUINO_STM32_FEATHER) && !defined(ARDUINO_UNOR4_WIFI)
+#if !defined(ARDUINO_UNOR4_MINIMA)
 #include "pins_arduino.h"
 #include "wiring_private.h"
+#endif
 #endif
 #include <SPI.h>
 


### PR DESCRIPTION
As mentioned on the Arduino forum, the library would not compile on the new boards. https://forum.arduino.cc/t/not-working-in-combination-with-adafruit-st7789/1145046

```
Adafruit_ST77xx.cpp:29:10: fatal error: wiring_private.h: No such file or directory
 #include "wiring_private.h"
```

So updated the conditional for the STM32_FEATHER to also not include it for these new boards.

I tried building for these two boards before and after the changes. 

I built and ran the graphictest example sketch on the UNO R4 Wifi board I have
with an Adafruit ST7789 display with the 320x240 and it works.

I tried building it for Teensy 4.1 and it still compiles.
