### PR TITLE
Replace 'boolean' with 'bool'

### DIFF
--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -224,7 +224,7 @@ void Adafruit_ST77xx::setColRowStart(int8_t col, int8_t row) {
  @param  enable True if you want the display ON, false OFF
  */
 /**************************************************************************/
-void Adafruit_ST77xx::enableDisplay(boolean enable) {
+void Adafruit_ST77xx::enableDisplay(bool enable) {
   sendCommand(enable ? ST77XX_DISPON : ST77XX_DISPOFF);
 }
 
@@ -234,7 +234,7 @@ void Adafruit_ST77xx::enableDisplay(boolean enable) {
  @param  enable True if you want the TE pin ON, false OFF
  */
 /**************************************************************************/
-void Adafruit_ST77xx::enableTearing(boolean enable) {
+void Adafruit_ST77xx::enableTearing(bool enable) {
   sendCommand(enable ? ST77XX_TEON : ST77XX_TEOFF);
 }
 
@@ -244,7 +244,7 @@ void Adafruit_ST77xx::enableTearing(boolean enable) {
  @param  enable True if you want sleep mode ON, false OFF
  */
 /**************************************************************************/
-void Adafruit_ST77xx::enableSleep(boolean enable) {
+void Adafruit_ST77xx::enableSleep(bool enable) {
   sendCommand(enable ? ST77XX_SLPIN : ST77XX_SLPOUT);
 }
 

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -99,9 +99,9 @@ public:
 
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void setRotation(uint8_t r);
-  void enableDisplay(boolean enable);
-  void enableTearing(boolean enable);
-  void enableSleep(boolean enable);
+  void enableDisplay(bool enable);
+  void enableTearing(bool enable);
+  void enableSleep(bool enable);
 
 protected:
   uint8_t _colstart = 0,   ///< Some displays need this changed to offset

--- a/examples/seesaw_shield18_test/seesaw_shield18_test.ino
+++ b/examples/seesaw_shield18_test/seesaw_shield18_test.ino
@@ -185,8 +185,8 @@ void bmpDraw(char *filename, uint8_t x, uint16_t y) {
   uint32_t rowSize;               // Not always = bmpWidth; may have padding
   uint8_t  sdbuffer[3*BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
   uint8_t  buffidx = sizeof(sdbuffer); // Current position in sdbuffer
-  boolean  goodBmp = false;       // Set to true on valid header parse
-  boolean  flip    = true;        // BMP is stored bottom-to-top
+  bool     goodBmp = false;       // Set to true on valid header parse
+  bool     flip    = true;        // BMP is stored bottom-to-top
   int      w, h, row, col;
   uint8_t  r, g, b;
   uint32_t pos = 0, startTime = millis();

--- a/examples/shieldtest/shieldtest.ino
+++ b/examples/shieldtest/shieldtest.ino
@@ -134,8 +134,8 @@ void bmpDraw(char *filename, uint8_t x, uint8_t y) {
   uint32_t rowSize;               // Not always = bmpWidth; may have padding
   uint8_t  sdbuffer[3*BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
   uint8_t  buffidx = sizeof(sdbuffer); // Current position in sdbuffer
-  boolean  goodBmp = false;       // Set to true on valid header parse
-  boolean  flip    = true;        // BMP is stored bottom-to-top
+  bool     goodBmp = false;       // Set to true on valid header parse
+  bool     flip    = true;        // BMP is stored bottom-to-top
   int      w, h, row, col;
   uint8_t  r, g, b;
   uint32_t pos = 0, startTime = millis();


### PR DESCRIPTION
This fixes warnings on STM32 about `boolean` being deprecated:

```
In file included from .pio/libdeps/default/Adafruit ST7735 and ST7789 Library/Adafruit_ST7789.h:4,                                   
                 from /home/adam/hardware/gps-tracker/src/gps-tracker.ino:4:                                                         
.pio/libdeps/default/Adafruit ST7735 and ST7789 Library/Adafruit_ST77xx.h:102:36: warning: 'boolean' is deprecated [-Wdeprecated-declarations]
  102 |   void enableDisplay(boolean enable);                                                                                        
      |                                    ^                                                                                         
In file included from /home/adam/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring.h:34,                            
                 from /home/adam/.platformio/packages/framework-arduinoststm32/cores/arduino/Arduino.h:36,                           
                 from /tmp/tmpiqlma7tp:1:                                                                                            
/home/adam/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring_constants.h:110:14: note: declared here                
  110 | typedef bool boolean __attribute__((deprecated));                                                                            
      |              ^~~~~~~
```