### PR TITLE
Add support for displays with blacktab colors and greentab offsets

### DIFF
--- a/Adafruit_ST7735.cpp
+++ b/Adafruit_ST7735.cpp
@@ -228,7 +228,7 @@ void Adafruit_ST7735::initB(void) {
 /**************************************************************************/
 void Adafruit_ST7735::initR(uint8_t options) {
   commonInit(Rcmd1);
-  if (options == INITR_GREENTAB) {
+  if ((options == INITR_GREENTAB) || (options == INITR_BLACKTAB_OFFSETS)) {
     displayInit(Rcmd2green);
     _colstart = 2;
     _rowstart = 1;
@@ -258,8 +258,8 @@ void Adafruit_ST7735::initR(uint8_t options) {
   }
   displayInit(Rcmd3);
 
-  // Black tab, change MADCTL color filter
-  if ((options == INITR_BLACKTAB) || (options == INITR_MINI160x80)) {
+  // Black tab or similar, change MADCTL color filter
+  if ((options == INITR_BLACKTAB) || (options == INITR_MINI160x80) || (options == INITR_BLACKTAB_OFFSETS)) {
     uint8_t data = 0xC0;
     sendCommand(ST77XX_MADCTL, &data, 1);
   }
@@ -295,11 +295,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
 
   switch (rotation) {
   case 0:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
-      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
-    } else {
-      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST7735_MADCTL_BGR;
-    }
+    madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY;
 
     if (tabcolor == INITR_144GREENTAB) {
       _height = ST7735_TFTHEIGHT_128;
@@ -316,11 +312,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 1:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
-      madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
-    } else {
-      madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
-    }
+    madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV;
 
     if (tabcolor == INITR_144GREENTAB) {
       _width = ST7735_TFTHEIGHT_128;
@@ -337,12 +329,6 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _xstart = _rowstart;
     break;
   case 2:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
-      madctl = ST77XX_MADCTL_RGB;
-    } else {
-      madctl = ST7735_MADCTL_BGR;
-    }
-
     if (tabcolor == INITR_144GREENTAB) {
       _height = ST7735_TFTHEIGHT_128;
       _width = ST7735_TFTWIDTH_128;
@@ -358,11 +344,7 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _rowstart;
     break;
   case 3:
-    if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80)) {
-      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
-    } else {
-      madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
-    }
+    madctl = ST77XX_MADCTL_MX | ST77XX_MADCTL_MV;
 
     if (tabcolor == INITR_144GREENTAB) {
       _width = ST7735_TFTHEIGHT_128;
@@ -378,6 +360,13 @@ void Adafruit_ST7735::setRotation(uint8_t m) {
     _ystart = _colstart;
     _xstart = _rowstart;
     break;
+  }
+
+  // Black tab or similar, change MADCTL color filter
+  if ((tabcolor == INITR_BLACKTAB) || (tabcolor == INITR_MINI160x80) || (tabcolor == INITR_BLACKTAB_OFFSETS)) {
+    madctl = madctl | ST77XX_MADCTL_RGB;
+  } else {
+    madctl = madctl | ST7735_MADCTL_BGR;
   }
 
   sendCommand(ST77XX_MADCTL, &madctl, 1);

--- a/Adafruit_ST7735.h
+++ b/Adafruit_ST7735.h
@@ -14,6 +14,7 @@
 #define INITR_MINI160x80 0x04
 #define INITR_HALLOWING 0x05
 #define INITR_MINI160x80_PLUGIN 0x06
+#define INITR_BLACKTAB_OFFSETS 0x07  // like black tab, but with offsets of green tab
 
 // Some register settings
 #define ST7735_MADCTL_BGR 0x08


### PR DESCRIPTION
This change fixes #191, #180 and #154 by creating a flag named `INITR_BLACKTAB_OFFSETS` for `initR` for the displays described in the issue reports. When `initR` is called with this flag, the commands for second stage initialization of greentab displays are used, but MADCTL is modified like when `INITR_BLACKTAB` is used. I have also modified `Adafruit_ST7735::setRotation`, as it alters MADCTL. I have simplified the function to avoid repeating code for checking if the color order flag in MADCTL should be changed. This change is tested, it works on the mentioned displays and doesn't alter the functionality when `INITR_BLACKTAB` or `INITR_GREENTAB` is used.
This pull request aims to fix the same issue as #168, which contains a bug that causes an erroneous modification of its behavior when `initR` is used with `INITR_GREENTAB`, which I have described in comments below that pull request.
My pull request doesn't modify the examples, as I wasn't sure if adding a commented out `initR` with `INITR_BLACKTAB_OFFSETS` to e.g. `graphicstest` is suitable, as this type of displays isn't an official one.
PS: In #191, I was told to contact Deek-Robot rather than submitting a pull request myself. I decided otherwise, as their website doesn't list my TFT as one of their products (even though the URL of the company is written on the display) and I didn't want to risk waiting for a long time if I can fix this myself. Another reason is that this issue isn't exclusive to Deek-Robot displays.