### PR TITLE
Update graphicstest_tft_gizmo.ino

### DIFF
--- a/examples/graphicstest_tft_gizmo/graphicstest_tft_gizmo.ino
+++ b/examples/graphicstest_tft_gizmo/graphicstest_tft_gizmo.ino
@@ -50,13 +50,13 @@ void setup(void) {
   Serial.begin(9600);
   Serial.print(F("Hello! Gizmo TFT Test"));
 
-  pinMode(TFT_BACKLIGHT, OUTPUT);
-  digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
-
   tft.init(240, 240);                // Init ST7789 240x240
   tft.setRotation(2);
 
   Serial.println(F("Initialized"));
+
+  pinMode(TFT_BACKLIGHT, OUTPUT);
+  digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
 
   uint16_t time = millis();
   tft.fillScreen(ST77XX_BLACK);


### PR DESCRIPTION
Minor change. Do not turn on backlight until display is initialized or it will toggle back off. 

Based on [github issue](#199)

Forum issues:
[TFT Gizmo not working with Arduino sketch](https://forums.adafruit.com/viewtopic.php?t=210725)

[noobie needs help with TFT Gizmo!](https://forums.adafruit.com/viewtopic.php?t=210755)

Test and run on Gizmo + CPB using hardware SPI or software SPI. 

```
* 0.9.0 bootloader
* Arduino 2.3.2
* Adafruit nRF52 BSP 1.6.1
```

```
Using library Adafruit GFX Library at version 1.11.9 in folder: /Users/sklarm/Documents/Arduino/libraries/Adafruit_GFX_Library 
Using library Adafruit BusIO at version 1.16.0 in folder: /Users/sklarm/Documents/Arduino/libraries/Adafruit_BusIO 
Using library Wire at version 1.0 in folder: /Users/sklarm/Library/Arduino15/packages/adafruit/hardware/nrf52/1.6.1/libraries/Wire 
Using library SPI at version 1.0 in folder: /Users/sklarm/Library/Arduino15/packages/adafruit/hardware/nrf52/1.6.1/libraries/SPI 
Using library Adafruit ST7735 and ST7789 Library at version 1.10.3 in folder: /Users/sklarm/Documents/Arduino/libraries/Adafruit_ST7735_and_ST7789_Library 
Using library Adafruit TinyUSB Library at version 3.1.4 in folder: /Users/sklarm/Documents/Arduino/libraries/Adafruit_TinyUSB_Library 
```

