### PR TITLE
Add support for Arduino Nesso-N1 (ST7789P3)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,243 @@
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
+## use pip install clang-format==18.1.3
 Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ doxygen_sqlite3.db
 html
 /.vs
 *.DS_Store
+.vscode/
+build/
+.vs/
+.pio/

--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -37,6 +37,30 @@ Adafruit_ST7789::Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc,
     : Adafruit_ST77xx(240, 320, spiClass, cs, dc, rst) {}
 #endif // end !ESP8266
 
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+Adafruit_ST7789::Adafruit_ST7789(int8_t cs, ExpanderPin *dc, ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, cs, dc, rst) {}
+
+Adafruit_ST7789::Adafruit_ST7789(int8_t cs, int8_t dc, ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, cs, dc, rst) {}
+
+Adafruit_ST7789::Adafruit_ST7789(ExpanderPin *cs, ExpanderPin *dc,
+                                 ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, cs, dc, rst) {}
+
+Adafruit_ST7789::Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc,
+                                 ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, spiClass, cs, dc, rst) {}
+
+Adafruit_ST7789::Adafruit_ST7789(SPIClass *spiClass, int8_t cs, ExpanderPin *dc,
+                                 ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, spiClass, cs, dc, rst) {}
+
+Adafruit_ST7789::Adafruit_ST7789(SPIClass *spiClass, ExpanderPin *cs,
+                                 ExpanderPin *dc, ExpanderPin *rst)
+    : Adafruit_ST77xx(240, 320, spiClass, cs, dc, rst) {}
+#endif
+
 // SCREEN INITIALIZATION ***************************************************
 
 // Rather than a bazillion writecommand() and writedata() calls, screen
@@ -102,6 +126,15 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
   // case-by-case basis.)
 
   commonInit(NULL);
+
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+  if (width == 135 && height == 240 && _rstExp != nullptr) {
+    _rowstart = 40;
+    _rowstart2 = 40;
+    _colstart = 53;
+    _colstart2 = 52;
+  } else
+#endif
   if (width == 240 && height == 240) {
     // 1.3", 1.54" displays (right justified)
     _rowstart = (320 - height);

--- a/Adafruit_ST7789.cpp
+++ b/Adafruit_ST7789.cpp
@@ -135,7 +135,7 @@ void Adafruit_ST7789::init(uint16_t width, uint16_t height, uint8_t mode) {
     _colstart2 = 52;
   } else
 #endif
-  if (width == 240 && height == 240) {
+      if (width == 240 && height == 240) {
     // 1.3", 1.54" displays (right justified)
     _rowstart = (320 - height);
     _rowstart2 = 0;

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -5,28 +5,30 @@
 
 /// Subclass of ST77XX type display for ST7789 TFT Driver
 class Adafruit_ST7789 : public Adafruit_ST77xx {
-  public:
+public:
   Adafruit_ST7789(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
-    int8_t rst = -1);
-    Adafruit_ST7789(int8_t cs, int8_t dc, int8_t rst);
-    #if !defined(ESP8266)
-    Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
-    #endif // end !ESP8266
-    #if defined(ARDUINO_ARDUINO_NESSO_N1)
+                  int8_t rst = -1);
+  Adafruit_ST7789(int8_t cs, int8_t dc, int8_t rst);
+#if !defined(ESP8266)
+  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
+#endif // end !ESP8266
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
   Adafruit_ST7789(int8_t cs, ExpanderPin *dc, ExpanderPin *rst = NULL);
   Adafruit_ST7789(int8_t cs, int8_t dc, ExpanderPin *rst = NULL);
   Adafruit_ST7789(ExpanderPin *cs, ExpanderPin *dc, ExpanderPin *rst = NULL);
   Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, ExpanderPin *rst);
-  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, ExpanderPin *dc, ExpanderPin *rst);
-  Adafruit_ST7789(SPIClass *spiClass, ExpanderPin *cs, ExpanderPin *dc, ExpanderPin *rst);
+  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, ExpanderPin *dc,
+                  ExpanderPin *rst);
+  Adafruit_ST7789(SPIClass *spiClass, ExpanderPin *cs, ExpanderPin *dc,
+                  ExpanderPin *rst);
 #endif
 
-void setRotation(uint8_t m);
-void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
+  void setRotation(uint8_t m);
+  void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
 
 protected:
-uint8_t _colstart2 = 0, ///< Offset from the right
-_rowstart2 = 0;     ///< Offset from the bottom
+  uint8_t _colstart2 = 0, ///< Offset from the right
+      _rowstart2 = 0;     ///< Offset from the bottom
 #if defined(ARDUINO_ARDUINO_NESSO_N1)
   ExpanderPin *cs = nullptr;
   ExpanderPin *dc = nullptr;

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -2,7 +2,6 @@
 #define _ADAFRUIT_ST7789H_
 
 #include "Adafruit_ST77xx.h"
-// extern class ExpanderPin;
 
 /// Subclass of ST77XX type display for ST7789 TFT Driver
 class Adafruit_ST7789 : public Adafruit_ST77xx {

--- a/Adafruit_ST7789.h
+++ b/Adafruit_ST7789.h
@@ -2,23 +2,37 @@
 #define _ADAFRUIT_ST7789H_
 
 #include "Adafruit_ST77xx.h"
+// extern class ExpanderPin;
 
 /// Subclass of ST77XX type display for ST7789 TFT Driver
 class Adafruit_ST7789 : public Adafruit_ST77xx {
-public:
+  public:
   Adafruit_ST7789(int8_t cs, int8_t dc, int8_t mosi, int8_t sclk,
-                  int8_t rst = -1);
-  Adafruit_ST7789(int8_t cs, int8_t dc, int8_t rst);
-#if !defined(ESP8266)
-  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
-#endif // end !ESP8266
+    int8_t rst = -1);
+    Adafruit_ST7789(int8_t cs, int8_t dc, int8_t rst);
+    #if !defined(ESP8266)
+    Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, int8_t rst);
+    #endif // end !ESP8266
+    #if defined(ARDUINO_ARDUINO_NESSO_N1)
+  Adafruit_ST7789(int8_t cs, ExpanderPin *dc, ExpanderPin *rst = NULL);
+  Adafruit_ST7789(int8_t cs, int8_t dc, ExpanderPin *rst = NULL);
+  Adafruit_ST7789(ExpanderPin *cs, ExpanderPin *dc, ExpanderPin *rst = NULL);
+  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, int8_t dc, ExpanderPin *rst);
+  Adafruit_ST7789(SPIClass *spiClass, int8_t cs, ExpanderPin *dc, ExpanderPin *rst);
+  Adafruit_ST7789(SPIClass *spiClass, ExpanderPin *cs, ExpanderPin *dc, ExpanderPin *rst);
+#endif
 
-  void setRotation(uint8_t m);
-  void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
+void setRotation(uint8_t m);
+void init(uint16_t width, uint16_t height, uint8_t spiMode = SPI_MODE0);
 
 protected:
-  uint8_t _colstart2 = 0, ///< Offset from the right
-      _rowstart2 = 0;     ///< Offset from the bottom
+uint8_t _colstart2 = 0, ///< Offset from the right
+_rowstart2 = 0;     ///< Offset from the bottom
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+  ExpanderPin *cs = nullptr;
+  ExpanderPin *dc = nullptr;
+  ExpanderPin *rst = nullptr;
+#endif
 
 private:
   uint16_t windowWidth;

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -83,6 +83,33 @@ Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
     : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
 #endif // end !ESP8266
 
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
+                                 int8_t cs, ExpanderPin *dc, ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
+
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
+                                 int8_t cs, int8_t dc, ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
+
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass,
+                                 ExpanderPin *cs, ExpanderPin *dc,
+                                 ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, spiClass, cs, dc, rst) {}
+
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs,
+                                 ExpanderPin *dc, ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, cs, dc, rst) {}
+
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
+                                 ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, cs, dc, rst) {}
+
+Adafruit_ST77xx::Adafruit_ST77xx(uint16_t w, uint16_t h, ExpanderPin *cs,
+                                 ExpanderPin *dc, ExpanderPin *rst)
+    : Adafruit_SPITFT(w, h, cs, dc, rst) {}
+#endif
+
 /**************************************************************************/
 /*!
     @brief  Companion code to the initiliazation tables. Reads and issues

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -25,18 +25,19 @@
 #ifndef _ADAFRUIT_ST77XXH_
 #define _ADAFRUIT_ST77XXH_
 
-#include "Arduino.h"
-#include "Print.h"
 #include <Adafruit_GFX.h>
 #include <Adafruit_SPITFT.h>
 #include <Adafruit_SPITFT_Macros.h>
 
-#define ST7735_TFTWIDTH_128 128  // for 1.44 and mini
-#define ST7735_TFTWIDTH_80 80    // for mini
-#define ST7735_TFTHEIGHT_128 128 // for 1.44" display
-#define ST7735_TFTHEIGHT_160 160 // for 1.8" and mini display
+#include "Arduino.h"
+#include "Print.h"
 
-#define ST_CMD_DELAY 0x80 // special signifier for command lists
+#define ST7735_TFTWIDTH_128 128   // for 1.44 and mini
+#define ST7735_TFTWIDTH_80 80     // for mini
+#define ST7735_TFTHEIGHT_128 128  // for 1.44" display
+#define ST7735_TFTHEIGHT_160 160  // for 1.8" and mini display
+
+#define ST_CMD_DELAY 0x80  // special signifier for command lists
 
 #define ST77XX_NOP 0x00
 #define ST77XX_SWRESET 0x01
@@ -87,15 +88,29 @@
 
 /// Subclass of SPITFT for ST77xx displays (lots in common!)
 class Adafruit_ST77xx : public Adafruit_SPITFT {
-public:
+ public:
   Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI,
                   int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
   Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t CS, int8_t RS,
                   int8_t RST = -1);
 #if !defined(ESP8266)
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t CS,
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t CS,
                   int8_t RS, int8_t RST = -1);
-#endif // end !ESP8266
+#endif  // end !ESP8266
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t cs,
+                  ExpanderPin* dc, ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t cs,
+                  int8_t dc, ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, ExpanderPin* cs,
+                  ExpanderPin* dc, ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, ExpanderPin* dc,
+                  ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
+                  ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, ExpanderPin* cs, ExpanderPin* dc,
+                  ExpanderPin* rst = NULL);
+#endif
 
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void setRotation(uint8_t r);
@@ -103,15 +118,15 @@ public:
   void enableTearing(boolean enable);
   void enableSleep(boolean enable);
 
-protected:
-  uint8_t _colstart = 0,   ///< Some displays need this changed to offset
-      _rowstart = 0,       ///< Some displays need this changed to offset
-      spiMode = SPI_MODE0; ///< Certain display needs MODE3 instead
+ protected:
+  uint8_t _colstart = 0,    ///< Some displays need this changed to offset
+      _rowstart = 0,        ///< Some displays need this changed to offset
+      spiMode = SPI_MODE0;  ///< Certain display needs MODE3 instead
 
   void begin(uint32_t freq = 0);
-  void commonInit(const uint8_t *cmdList);
-  void displayInit(const uint8_t *addr);
+  void commonInit(const uint8_t* cmdList);
+  void displayInit(const uint8_t* addr);
   void setColRowStart(int8_t col, int8_t row);
 };
 
-#endif // _ADAFRUIT_ST77XXH_
+#endif  // _ADAFRUIT_ST77XXH_

--- a/Adafruit_ST77xx.h
+++ b/Adafruit_ST77xx.h
@@ -32,12 +32,12 @@
 #include "Arduino.h"
 #include "Print.h"
 
-#define ST7735_TFTWIDTH_128 128   // for 1.44 and mini
-#define ST7735_TFTWIDTH_80 80     // for mini
-#define ST7735_TFTHEIGHT_128 128  // for 1.44" display
-#define ST7735_TFTHEIGHT_160 160  // for 1.8" and mini display
+#define ST7735_TFTWIDTH_128 128  // for 1.44 and mini
+#define ST7735_TFTWIDTH_80 80    // for mini
+#define ST7735_TFTHEIGHT_128 128 // for 1.44" display
+#define ST7735_TFTHEIGHT_160 160 // for 1.8" and mini display
 
-#define ST_CMD_DELAY 0x80  // special signifier for command lists
+#define ST_CMD_DELAY 0x80 // special signifier for command lists
 
 #define ST77XX_NOP 0x00
 #define ST77XX_SWRESET 0x01
@@ -88,28 +88,28 @@
 
 /// Subclass of SPITFT for ST77xx displays (lots in common!)
 class Adafruit_ST77xx : public Adafruit_SPITFT {
- public:
+public:
   Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t _CS, int8_t _DC, int8_t _MOSI,
                   int8_t _SCLK, int8_t _RST = -1, int8_t _MISO = -1);
   Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t CS, int8_t RS,
                   int8_t RST = -1);
 #if !defined(ESP8266)
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t CS,
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t CS,
                   int8_t RS, int8_t RST = -1);
-#endif  // end !ESP8266
+#endif // end !ESP8266
 #if defined(ARDUINO_ARDUINO_NESSO_N1)
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t cs,
-                  ExpanderPin* dc, ExpanderPin* rst = NULL);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, int8_t cs,
-                  int8_t dc, ExpanderPin* rst = NULL);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass* spiClass, ExpanderPin* cs,
-                  ExpanderPin* dc, ExpanderPin* rst = NULL);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, ExpanderPin* dc,
-                  ExpanderPin* rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t cs,
+                  ExpanderPin *dc, ExpanderPin *rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, int8_t cs,
+                  int8_t dc, ExpanderPin *rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, SPIClass *spiClass, ExpanderPin *cs,
+                  ExpanderPin *dc, ExpanderPin *rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, ExpanderPin *dc,
+                  ExpanderPin *rst = NULL);
   Adafruit_ST77xx(uint16_t w, uint16_t h, int8_t cs, int8_t dc,
-                  ExpanderPin* rst = NULL);
-  Adafruit_ST77xx(uint16_t w, uint16_t h, ExpanderPin* cs, ExpanderPin* dc,
-                  ExpanderPin* rst = NULL);
+                  ExpanderPin *rst = NULL);
+  Adafruit_ST77xx(uint16_t w, uint16_t h, ExpanderPin *cs, ExpanderPin *dc,
+                  ExpanderPin *rst = NULL);
 #endif
 
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
@@ -118,15 +118,15 @@ class Adafruit_ST77xx : public Adafruit_SPITFT {
   void enableTearing(boolean enable);
   void enableSleep(boolean enable);
 
- protected:
-  uint8_t _colstart = 0,    ///< Some displays need this changed to offset
-      _rowstart = 0,        ///< Some displays need this changed to offset
-      spiMode = SPI_MODE0;  ///< Certain display needs MODE3 instead
+protected:
+  uint8_t _colstart = 0,   ///< Some displays need this changed to offset
+      _rowstart = 0,       ///< Some displays need this changed to offset
+      spiMode = SPI_MODE0; ///< Certain display needs MODE3 instead
 
   void begin(uint32_t freq = 0);
-  void commonInit(const uint8_t* cmdList);
-  void displayInit(const uint8_t* addr);
+  void commonInit(const uint8_t *cmdList);
+  void displayInit(const uint8_t *addr);
   void setColRowStart(int8_t col, int8_t row);
 };
 
-#endif  // _ADAFRUIT_ST77XXH_
+#endif // _ADAFRUIT_ST77XXH_

--- a/examples/graphicstest_nesso-n1/graphicstest_nesso-n1.ino
+++ b/examples/graphicstest_nesso-n1/graphicstest_nesso-n1.ino
@@ -1,0 +1,358 @@
+/**************************************************************************
+  This is a library for several Adafruit displays based on ST77* drivers.
+
+  This example works with the 1.14" TFT breakout
+    ----> https://www.adafruit.com/product/4383
+  The 1.3" TFT breakout
+    ----> https://www.adafruit.com/product/4313
+  The 1.47" TFT breakout
+    ----> https://www.adafruit.com/product/5393
+  The 1.54" TFT breakout
+    ----> https://www.adafruit.com/product/3787
+  The 1.69" TFT breakout
+    ----> https://www.adafruit.com/product/5206
+  The 1.9" TFT breakout
+    ----> https://www.adafruit.com/product/5394
+  The 2.0" TFT breakout
+    ----> https://www.adafruit.com/product/4311
+
+
+  Check out the links above for our tutorials and wiring diagrams.
+  These displays use SPI to communicate, 4 or 5 pins are required to
+  interface (RST is optional).
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ **************************************************************************/
+
+#include <Adafruit_GFX.h>    // Core graphics library
+#include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
+#include <SPI.h>
+
+#if defined(ARDUINO_FEATHER_ESP32) // Feather Huzzah32
+  #define TFT_CS         14
+  #define TFT_RST        15
+  #define TFT_DC         32
+
+#elif defined(ESP8266)
+  #define TFT_CS         4
+  #define TFT_RST        16
+  #define TFT_DC         5
+
+#elif defined(ARDUINO_ARDUINO_NESSO_N1)
+  #define TFT_CS LCD_CS
+  #define TFT_RST &LCD_RESET
+  #define TFT_DC LCD_RS
+
+#else
+  // For the breakout board, you can use any 2 or 3 pins.
+  // These pins will also work for the 1.8" TFT shield.
+  #define TFT_CS        10
+  #define TFT_RST        9 // Or set to -1 and connect to Arduino RESET pin
+  #define TFT_DC         8
+#endif
+
+// OPTION 1 (recommended) is to use the HARDWARE SPI pins, which are unique
+// to each board and not reassignable. For Arduino Uno: MOSI = pin 11 and
+// SCLK = pin 13. This is the fastest mode of operation and is required if
+// using the breakout board's microSD card.
+
+Adafruit_ST7789 tft = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_RST);
+
+// OPTION 2 lets you interface the display using ANY TWO or THREE PINS,
+// tradeoff being that performance is not as fast as hardware SPI above.
+//#define TFT_MOSI 11  // Data out
+//#define TFT_SCLK 13  // Clock out
+
+//Adafruit_ST7789 tft = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+
+
+float p = 3.1415926;
+
+void setup(void) {
+  Serial.begin(9600);
+  Serial.print(F("Hello! ST77xx TFT Test"));
+
+  // Use this initializer (uncomment) if using a 1.3" or 1.54" 240x240 TFT:
+  //tft.init(240, 240);           // Init ST7789 240x240
+
+  // OR use this initializer (uncomment) if using a 1.69" 280x240 TFT:
+  //tft.init(240, 280);           // Init ST7789 280x240
+
+  // OR use this initializer (uncomment) if using a 2.0" 320x240 TFT:
+  //tft.init(240, 320);           // Init ST7789 320x240
+
+  // OR use this initializer (uncomment) if using a 1.14" 240x135 TFT:
+  tft.init(135, 240);           // Init ST7789 240x135
+  
+  // OR use this initializer (uncomment) if using a 1.47" 172x320 TFT:
+  //tft.init(172, 320);           // Init ST7789 172x320
+
+  // OR use this initializer (uncomment) if using a 1.9" 170x320 TFT:
+  //tft.init(170, 320);           // Init ST7789 170x320
+
+  tft.invertDisplay(true);
+
+  // SPI speed defaults to SPI_DEFAULT_FREQ defined in the library, you can override it here
+  // Note that speed allowable depends on chip and quality of wiring, if you go too fast, you
+  // may end up with a black screen some times, or all the time.
+  //tft.setSPISpeed(40000000);
+
+#if defined(ARDUINO_ARDUINO_NESSO_N1)
+  pinMode(LCD_BACKLIGHT, OUTPUT);
+  digitalWrite(LCD_BACKLIGHT, HIGH);
+#endif
+
+  Serial.println(F("Initialized"));
+
+  uint16_t time = millis();
+  tft.fillScreen(ST77XX_BLACK);
+  time = millis() - time;
+
+  Serial.println(time, DEC);
+  delay(500);
+
+  // large block of text
+  tft.fillScreen(ST77XX_BLACK);
+  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", ST77XX_WHITE);
+  delay(1000);
+
+  // tft print function!
+  tftPrintTest();
+  delay(4000);
+
+  // a single pixel
+  tft.drawPixel(tft.width()/2, tft.height()/2, ST77XX_GREEN);
+  delay(500);
+
+  // line draw test
+  testlines(ST77XX_YELLOW);
+  delay(500);
+
+  // optimized lines
+  testfastlines(ST77XX_RED, ST77XX_BLUE);
+  delay(500);
+
+  testdrawrects(ST77XX_GREEN);
+  delay(500);
+
+  testfillrects(ST77XX_YELLOW, ST77XX_MAGENTA);
+  delay(500);
+
+  tft.fillScreen(ST77XX_BLACK);
+  testfillcircles(10, ST77XX_BLUE);
+  testdrawcircles(10, ST77XX_WHITE);
+  delay(500);
+
+  testroundrects();
+  delay(500);
+
+  testtriangles();
+  delay(500);
+
+  mediabuttons();
+  delay(500);
+
+  Serial.println("done");
+  delay(1000);
+}
+
+void loop() {
+  tft.invertDisplay(true);
+  delay(500);
+  tft.invertDisplay(false);
+  delay(500);
+}
+
+void testlines(uint16_t color) {
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=0; x < tft.width(); x+=6) {
+    tft.drawLine(0, 0, x, tft.height()-1, color);
+    delay(0);
+  }
+  for (int16_t y=0; y < tft.height(); y+=6) {
+    tft.drawLine(0, 0, tft.width()-1, y, color);
+    delay(0);
+  }
+
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=0; x < tft.width(); x+=6) {
+    tft.drawLine(tft.width()-1, 0, x, tft.height()-1, color);
+    delay(0);
+  }
+  for (int16_t y=0; y < tft.height(); y+=6) {
+    tft.drawLine(tft.width()-1, 0, 0, y, color);
+    delay(0);
+  }
+
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=0; x < tft.width(); x+=6) {
+    tft.drawLine(0, tft.height()-1, x, 0, color);
+    delay(0);
+  }
+  for (int16_t y=0; y < tft.height(); y+=6) {
+    tft.drawLine(0, tft.height()-1, tft.width()-1, y, color);
+    delay(0);
+  }
+
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=0; x < tft.width(); x+=6) {
+    tft.drawLine(tft.width()-1, tft.height()-1, x, 0, color);
+    delay(0);
+  }
+  for (int16_t y=0; y < tft.height(); y+=6) {
+    tft.drawLine(tft.width()-1, tft.height()-1, 0, y, color);
+    delay(0);
+  }
+}
+
+void testdrawtext(char *text, uint16_t color) {
+  tft.setCursor(0, 0);
+  tft.setTextColor(color);
+  tft.setTextWrap(true);
+  tft.print(text);
+}
+
+void testfastlines(uint16_t color1, uint16_t color2) {
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t y=0; y < tft.height(); y+=5) {
+    tft.drawFastHLine(0, y, tft.width(), color1);
+  }
+  for (int16_t x=0; x < tft.width(); x+=5) {
+    tft.drawFastVLine(x, 0, tft.height(), color2);
+  }
+}
+
+void testdrawrects(uint16_t color) {
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=0; x < tft.width(); x+=6) {
+    tft.drawRect(tft.width()/2 -x/2, tft.height()/2 -x/2 , x, x, color);
+  }
+}
+
+void testfillrects(uint16_t color1, uint16_t color2) {
+  tft.fillScreen(ST77XX_BLACK);
+  for (int16_t x=tft.width()-1; x > 6; x-=6) {
+    tft.fillRect(tft.width()/2 -x/2, tft.height()/2 -x/2 , x, x, color1);
+    tft.drawRect(tft.width()/2 -x/2, tft.height()/2 -x/2 , x, x, color2);
+  }
+}
+
+void testfillcircles(uint8_t radius, uint16_t color) {
+  for (int16_t x=radius; x < tft.width(); x+=radius*2) {
+    for (int16_t y=radius; y < tft.height(); y+=radius*2) {
+      tft.fillCircle(x, y, radius, color);
+    }
+  }
+}
+
+void testdrawcircles(uint8_t radius, uint16_t color) {
+  for (int16_t x=0; x < tft.width()+radius; x+=radius*2) {
+    for (int16_t y=0; y < tft.height()+radius; y+=radius*2) {
+      tft.drawCircle(x, y, radius, color);
+    }
+  }
+}
+
+void testtriangles() {
+  tft.fillScreen(ST77XX_BLACK);
+  uint16_t color = 0xF800;
+  int t;
+  int w = tft.width()/2;
+  int x = tft.height()-1;
+  int y = 0;
+  int z = tft.width();
+  for(t = 0 ; t <= 15; t++) {
+    tft.drawTriangle(w, y, y, x, z, x, color);
+    x-=4;
+    y+=4;
+    z-=4;
+    color+=100;
+  }
+}
+
+void testroundrects() {
+  tft.fillScreen(ST77XX_BLACK);
+  uint16_t color = 100;
+  int i;
+  int t;
+  for(t = 0 ; t <= 4; t+=1) {
+    int x = 0;
+    int y = 0;
+    int w = tft.width()-2;
+    int h = tft.height()-2;
+    for(i = 0 ; i <= 16; i+=1) {
+      tft.drawRoundRect(x, y, w, h, 5, color);
+      x+=2;
+      y+=3;
+      w-=4;
+      h-=6;
+      color+=1100;
+    }
+    color+=100;
+  }
+}
+
+void tftPrintTest() {
+  tft.setTextWrap(false);
+  tft.fillScreen(ST77XX_BLACK);
+  tft.setCursor(0, 30);
+  tft.setTextColor(ST77XX_RED);
+  tft.setTextSize(1);
+  tft.println("Hello World!");
+  tft.setTextColor(ST77XX_YELLOW);
+  tft.setTextSize(2);
+  tft.println("Hello World!");
+  tft.setTextColor(ST77XX_GREEN);
+  tft.setTextSize(3);
+  tft.println("Hello World!");
+  tft.setTextColor(ST77XX_BLUE);
+  tft.setTextSize(4);
+  tft.print(1234.567);
+  delay(1500);
+  tft.setCursor(0, 0);
+  tft.fillScreen(ST77XX_BLACK);
+  tft.setTextColor(ST77XX_WHITE);
+  tft.setTextSize(0);
+  tft.println("Hello World!");
+  tft.setTextSize(1);
+  tft.setTextColor(ST77XX_GREEN);
+  tft.print(p, 6);
+  tft.println(" Want pi?");
+  tft.println(" ");
+  tft.print(8675309, HEX); // print 8,675,309 out in HEX!
+  tft.println(" Print HEX!");
+  tft.println(" ");
+  tft.setTextColor(ST77XX_WHITE);
+  tft.println("Sketch has been");
+  tft.println("running for: ");
+  tft.setTextColor(ST77XX_MAGENTA);
+  tft.print(millis() / 1000);
+  tft.setTextColor(ST77XX_WHITE);
+  tft.print(" seconds.");
+}
+
+void mediabuttons() {
+  // play
+  tft.fillScreen(ST77XX_BLACK);
+  tft.fillRoundRect(25, 10, 78, 60, 8, ST77XX_WHITE);
+  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_RED);
+  delay(500);
+  // pause
+  tft.fillRoundRect(25, 90, 78, 60, 8, ST77XX_WHITE);
+  tft.fillRoundRect(39, 98, 20, 45, 5, ST77XX_GREEN);
+  tft.fillRoundRect(69, 98, 20, 45, 5, ST77XX_GREEN);
+  delay(500);
+  // play color
+  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_BLUE);
+  delay(50);
+  // pause color
+  tft.fillRoundRect(39, 98, 20, 45, 5, ST77XX_RED);
+  tft.fillRoundRect(69, 98, 20, 45, 5, ST77XX_RED);
+  // play color
+  tft.fillTriangle(42, 20, 42, 60, 90, 40, ST77XX_GREEN);
+}


### PR DESCRIPTION
Initially updated just the ST7789 to support ExpanderPin arguments to the constructor, which calls through ST77xx and Adafruit_GFX/Adafruit_SPITFT.

[Arduino Nesso-N1](https://docs.arduino.cc/hardware/nesso-n1) uses the ST7789P3, with various offsets, reference https://github.com/m5stack/M5GFX/blob/master/src/M5GFX.cpp#L2154-L2262
(-EDIT- presumably I was linking to https://github.com/m5stack/M5GFX/blob/edc877ac0a1a6f8dcbeb25d5b55c858fdc35d49e/src/M5GFX.cpp#L2496-L2521)

Probably needs thinking about how users might play with ExpanderPins and external displays, but minor guard (_rstExp != nullptr) in the row/column offset setup so at least that's covered.

![IMG_20251119_224313_8](https://github.com/user-attachments/assets/24869184-184f-4cbf-b719-825ee0b4e11d)
