### PR TITLE
Builds on Arduino UNO Q - other zephyr boards?

### DIFF
--- a/Adafruit_ST7796S.cpp
+++ b/Adafruit_ST7796S.cpp
@@ -72,38 +72,38 @@ static const uint8_t PROGMEM st7796s_init[] = {14, // 14 commands
 
 /**
  * @brief Constructor with software SPI.
- * @param CS Chip select pin.
- * @param RS Data/command pin.
- * @param MOSI SPI MOSI pin.
- * @param SCLK SPI clock pin.
- * @param RST Reset pin (optional).
+ * @param cs Chip select pin.
+ * @param rs Data/command pin.
+ * @param mosi SPI MOSI pin.
+ * @param sclk SPI clock pin.
+ * @param rst Reset pin (optional).
  */
-Adafruit_ST7796S::Adafruit_ST7796S(int8_t CS, int8_t RS, int8_t MOSI,
-                                   int8_t SCLK, int8_t RST)
-    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, CS, RS, MOSI, SCLK,
-                      RST) {}
+Adafruit_ST7796S::Adafruit_ST7796S(int8_t cs, int8_t rs, int8_t mosi,
+                                   int8_t sclk, int8_t rst)
+    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, cs, rs, mosi, sclk,
+                      rst) {}
 
 /**
  * @brief Constructor with hardware SPI.
- * @param CS Chip select pin.
- * @param RS Data/command pin.
- * @param RST Reset pin (optional).
+ * @param cs Chip select pin.
+ * @param rs Data/command pin.
+ * @param rst Reset pin (optional).
  */
-Adafruit_ST7796S::Adafruit_ST7796S(int8_t CS, int8_t RS, int8_t RST)
-    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, CS, RS, RST) {}
+Adafruit_ST7796S::Adafruit_ST7796S(int8_t cs, int8_t rs, int8_t rst)
+    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, cs, rs, rst) {}
 
 #if !defined(ESP8266)
 /**
  * @brief Constructor with hardware SPI and custom SPI class.
  * @param spiClass Pointer to SPI class.
- * @param CS Chip select pin.
- * @param RS Data/command pin.
- * @param RST Reset pin (optional).
+ * @param cs Chip select pin.
+ * @param rs Data/command pin.
+ * @param rst Reset pin (optional).
  */
-Adafruit_ST7796S::Adafruit_ST7796S(SPIClass *spiClass, int8_t CS, int8_t RS,
-                                   int8_t RST)
-    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, spiClass, CS, RS,
-                      RST) {}
+Adafruit_ST7796S::Adafruit_ST7796S(SPIClass *spiClass, int8_t cs, int8_t rs,
+                                   int8_t rst)
+    : Adafruit_ST77xx(ST7796S_TFTWIDTH, ST7796S_TFTHEIGHT, spiClass, cs, rs,
+                      rst) {}
 #endif
 
 /**

--- a/Adafruit_ST7796S.h
+++ b/Adafruit_ST7796S.h
@@ -53,11 +53,11 @@ enum ST7796S_ColorOrder {
  */
 class Adafruit_ST7796S : public Adafruit_ST77xx {
 public:
-  Adafruit_ST7796S(int8_t CS, int8_t RS, int8_t MOSI, int8_t SCLK,
-                   int8_t RST = -1);
-  Adafruit_ST7796S(int8_t CS, int8_t RS, int8_t RST = -1);
+  Adafruit_ST7796S(int8_t cs, int8_t rs, int8_t mosi, int8_t sclk,
+                   int8_t rst = -1);
+  Adafruit_ST7796S(int8_t cs, int8_t rs, int8_t rst = -1);
 #if !defined(ESP8266)
-  Adafruit_ST7796S(SPIClass *spiClass, int8_t CS, int8_t RS, int8_t RST);
+  Adafruit_ST7796S(SPIClass *spiClass, int8_t cs, int8_t rs, int8_t rst);
 #endif
 
   void init(uint16_t width = ST7796S_TFTWIDTH,

--- a/Adafruit_ST77xx.cpp
+++ b/Adafruit_ST77xx.cpp
@@ -25,7 +25,7 @@
 #include "Adafruit_ST77xx.h"
 #include <limits.h>
 #if !defined(ARDUINO_STM32_FEATHER) && !defined(ARDUINO_UNOR4_WIFI)
-#if !defined(ARDUINO_UNOR4_MINIMA)
+#if !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_ARCH_ZEPHYR)
 #include "pins_arduino.h"
 #include "wiring_private.h"
 #endif


### PR DESCRIPTION
Resolves #221

Ran into a few things that are keeping this library and maybe others from building for the UNO Q.  Needed to add it to the list of boards that don't include pins_arduino.h and wiring_private.h 

Second issue, is the newer added ST7796S files defined the constructor parameters in upper case.  Example MOSI
However the Q variant has defines for these like:
#define MOSI 0

So lowercased these parameters in the .h and .cpp files for the three constructors.

Should have minimal effect, simply lower cased the parameters on constructors
to ST7796S and excluded boards with Zephyr stuff from including header files
that don't exist.

So far I have run the ST7796 code on an Zephyr build on a Portenta H7.
Modified the graphic test for ST7796 (not included here) and changed to
my CS/DC/RST pins and it runs.  Will also do the same on UNO Q which
is what was reported not working on the Arduino forums.
