### PR TITLE
fix: Replace arduino component dependency name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 idf_component_register(SRCS "Adafruit_ST77xx.cpp" "Adafruit_ST7735.cpp" "Adafruit_ST7789.cpp" 
                        INCLUDE_DIRS "."
-                       REQUIRES arduino Adafruit-GFX-Library)
+                       REQUIRES "arduino-esp32" Adafruit-GFX-Library)
 
 project(Adafruit-ST7735-Library)


### PR DESCRIPTION
This PR aims to fix build when using this library as an ESP-IDF component.

`arduino` currently is not recognized as a valid component name in the `CMakeLists.txt` file ; I replaced it with `arduino-esp32`.

It is aleady named like this in the Adafruit_BusIO library : https://github.com/adafruit/Adafruit_BusIO/blob/3b8364267c3ee6e16bad91bc2101aefbd5b5915f/CMakeLists.txt#L9